### PR TITLE
Fix: Resolve compilation error and correct feature flag typo

### DIFF
--- a/src/file_systems/clipboard.rs
+++ b/src/file_systems/clipboard.rs
@@ -176,7 +176,7 @@ mod tests {
     use image::RgbaImage;
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "ci-clibpoard"), ignore)]
+    #[cfg_attr(not(feature = "ci-clipboard"), ignore)]
     async fn upload_download_text_test() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let term = Term::stdout();
         let reporter: AppReporter = AppReporter::from(&term);
@@ -210,7 +210,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "ci-clibpoard"), ignore)]
+    #[cfg_attr(not(feature = "ci-clipboard"), ignore)]
     async fn upload_download_image_test() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let term = Term::stdout();
         let reporter: AppReporter = AppReporter::from(&term);


### PR DESCRIPTION
- Updated Rust from 1.75.0 to 1.87.0. This resolved a compilation error caused by the `image-webp` crate, which required a newer Rust version. After this update, all previously failing tests now pass.
- Corrected a typo in a feature flag name in `src/file_systems/clipboard.rs`, changing `ci-clibpoard` to `ci-clipboard`.

The 13 tests that were previously marked as ignored are intentionally skipped via feature flags (`#[cfg_attr(not(feature = "..."), ignore)]`). These are integration tests that depend on external services or specific environment configurations and are not considered broken.