### PR TITLE
Keep the release binary by not restoring the cargo cache before tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,10 @@ jobs:
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: "test"
+          # The action restores its cargo cache on every invocation, and the cached target
+          # directory does not carry the workspace binary, so a second restore here wiped the
+          # binary built by the previous step before it could be packaged.
+          use-rust-cache: false
           target: ${{ matrix.platform.target }}
           toolchain: ${{ matrix.toolchain }}
           args: "--locked --release"


### PR DESCRIPTION
The cross action restores its cargo cache on every invocation, and the cached target directory does not carry the workspace binary, so the restore before the test step wiped the freshly built binary and the packaging step failed on every native target of the v0.17.0 run. Disables the cache restore for the test invocation only.