### PR TITLE
Print one row per file in the copy output

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -100,7 +100,7 @@ impl CliCommand {
     }
 }
 
-#[derive(ValueEnum, Debug, Clone)]
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RedacterType {
     GcpDlp,
     AwsComprehend,

--- a/src/commands/copy_command.rs
+++ b/src/commands/copy_command.rs
@@ -491,8 +491,8 @@ async fn redact_upload_file<
     }
 }
 
-/// Why redaction did not happen, defaulting to "there was nothing left to redact"
-/// when the pipeline did not record a reason.
+/// Why redaction did not happen, defaulting to "no redacter applied" when the
+/// pipeline did not record a reason.
 fn not_redacted_reason(blocked: Option<crate::redacters::RedactionBlocked>) -> NotRedactedReason {
     use crate::redacters::RedactionBlocked;
     match blocked {
@@ -501,7 +501,7 @@ fn not_redacted_reason(blocked: Option<crate::redacters::RedactionBlocked>) -> N
         Some(RedactionBlocked::OcrImageFormatNotSupported) => {
             NotRedactedReason::OcrImageFormatNotSupported
         }
-        None => NotRedactedReason::AlreadyRedacted,
+        None => NotRedactedReason::NoRedacterApplied,
     }
 }
 

--- a/src/commands/copy_command.rs
+++ b/src/commands/copy_command.rs
@@ -1,3 +1,8 @@
+use crate::commands::copy_output::{
+    format_capabilities_line, format_file_row, format_legend, format_summary_line,
+    CopyCapabilities, CopyFileOutcome, CopyOutputStyles, CopySummary, NotRedactedReason,
+    SkipReason,
+};
 use crate::errors::AppError;
 use crate::file_converters::FileConverters;
 use crate::file_systems::{DetectFileSystem, FileSystemConnection, FileSystemRef};
@@ -7,10 +12,11 @@ use crate::redacters::{
 };
 use crate::reporter::AppReporter;
 use crate::AppResult;
-use console::{pad_str, Alignment, Style, Term};
+use console::{Style, Term};
 use futures::Stream;
 use gcloud_sdk::prost::bytes;
 use indicatif::*;
+use rvstruct::ValueStruct;
 use serde::Serialize;
 use std::error::Error;
 use std::time::{Duration, Instant};
@@ -47,6 +53,14 @@ impl CopyCommandOptions {
     }
 }
 
+/// What one file's transfer produced: the counters it feeds, the outcome its row
+/// shows, and its size for the closing summary.
+struct TransferReport {
+    result: TransferFileResult,
+    outcome: CopyFileOutcome,
+    file_size: Option<usize>,
+}
+
 pub async fn command_copy(
     term: &Term,
     source: &str,
@@ -56,6 +70,7 @@ pub async fn command_copy(
 ) -> AppResult<CopyCommandResult> {
     let term_reporter = AppReporter::from(term);
     let file_converters = FileConverters::new().init(&term_reporter).await?;
+    let styles = CopyOutputStyles::new();
 
     report_copy_info(
         term,
@@ -63,8 +78,8 @@ pub async fn command_copy(
         destination,
         &redacter_options,
         &file_converters,
-    )
-    .await?;
+        &styles,
+    )?;
 
     let bar = ProgressBar::new(1);
     bar.set_style(
@@ -95,13 +110,14 @@ pub async fn command_copy(
         None => None,
     };
 
+    let mut summary = CopySummary::default();
     let copy_result: AppResult<CopyCommandResult> = if source_fs.has_multiple_files().await? {
         if !destination_fs.accepts_multiple_files().await? {
             return Err(AppError::DestinationDoesNotSupportMultipleFiles {
                 destination: destination.to_string(),
             });
         }
-        bar.println("Copying directory and listing source files...");
+        tracing::debug!(source, "copying a directory and listing the source files");
         let source_files_result = source_fs
             .list_files(Some(&options.file_matcher), options.max_files_limit)
             .await?;
@@ -111,23 +127,29 @@ pub async fn command_copy(
             .iter()
             .map(|file| file.file_size.unwrap_or(0))
             .sum();
-        let bold_style = Style::new().bold();
         bar.println(
             format!(
                 "Found {} files. Total size: {}",
-                bold_style.apply_to(files_found),
-                bold_style.apply_to(HumanBytes(files_total_size as u64))
+                styles.highlighted.apply_to(files_found),
+                styles
+                    .highlighted
+                    .apply_to(HumanBytes(files_total_size as u64))
             )
             .as_str(),
         );
+        if files_found > 0 {
+            bar.println(format_legend(&styles));
+        }
 
         bar.set_length(files_found as u64);
 
         let mut total_files_copied = 0;
         let mut total_files_redacted = 0;
         let mut total_files_skipped = source_files_result.skipped;
+        summary.skipped = source_files_result.skipped;
+        summary.total_size = files_total_size as u64;
         for source_file in source_files {
-            match transfer_and_redact_file(
+            let report = transfer_and_redact_file(
                 term,
                 &bar,
                 Some(&source_file),
@@ -137,9 +159,10 @@ pub async fn command_copy(
                 &maybe_redacters,
                 &file_converters,
                 &mut redacter_throttler,
+                &styles,
             )
-            .await?
-            {
+            .await?;
+            match report.result {
                 TransferFileResult::Copied => total_files_copied += 1,
                 TransferFileResult::RedactedAndCopied => {
                     total_files_redacted += 1;
@@ -147,6 +170,7 @@ pub async fn command_copy(
                 }
                 TransferFileResult::Skipped => total_files_skipped += 1,
             }
+            summary.count(&report.outcome);
         }
         Ok(CopyCommandResult {
             files_copied: total_files_copied,
@@ -154,100 +178,99 @@ pub async fn command_copy(
             files_skipped: total_files_skipped,
         })
     } else {
-        Ok(
-            match transfer_and_redact_file(
-                term,
-                &bar,
-                None,
-                &mut source_fs,
-                &mut destination_fs,
-                &options,
-                &maybe_redacters,
-                &file_converters,
-                &mut redacter_throttler,
-            )
-            .await?
-            {
-                TransferFileResult::Copied => CopyCommandResult {
-                    files_copied: 1,
-                    files_redacted: 0,
-                    files_skipped: 0,
-                },
-                TransferFileResult::RedactedAndCopied => CopyCommandResult {
-                    files_copied: 1,
-                    files_redacted: 1,
-                    files_skipped: 0,
-                },
-                TransferFileResult::Skipped => CopyCommandResult {
-                    files_copied: 0,
-                    files_redacted: 0,
-                    files_skipped: 1,
-                },
-            },
+        bar.println(format_legend(&styles));
+        let report = transfer_and_redact_file(
+            term,
+            &bar,
+            None,
+            &mut source_fs,
+            &mut destination_fs,
+            &options,
+            &maybe_redacters,
+            &file_converters,
+            &mut redacter_throttler,
+            &styles,
         )
+        .await?;
+        summary.count(&report.outcome);
+        summary.total_size = report.file_size.unwrap_or(0) as u64;
+        Ok(match report.result {
+            TransferFileResult::Copied => CopyCommandResult {
+                files_copied: 1,
+                files_redacted: 0,
+                files_skipped: 0,
+            },
+            TransferFileResult::RedactedAndCopied => CopyCommandResult {
+                files_copied: 1,
+                files_redacted: 1,
+                files_skipped: 0,
+            },
+            TransferFileResult::Skipped => CopyCommandResult {
+                files_copied: 0,
+                files_redacted: 0,
+                files_skipped: 1,
+            },
+        })
     };
 
     destination_fs.close().await?;
     source_fs.close().await?;
+    bar.finish_and_clear();
+    term.write_line("")?;
+    term.write_line(format_summary_line(&summary, &styles).as_str())?;
     copy_result
 }
 
-async fn report_copy_info(
+impl CopySummary {
+    /// Adds one file's outcome to the counts shown in the summary.
+    fn count(&mut self, outcome: &CopyFileOutcome) {
+        match outcome {
+            CopyFileOutcome::Redacted { .. } => self.redacted += 1,
+            CopyFileOutcome::Copied | CopyFileOutcome::CopiedUnredacted { .. } => {
+                self.copied_as_is += 1
+            }
+            CopyFileOutcome::Skipped { .. } => self.skipped += 1,
+            CopyFileOutcome::Error { .. } => self.errors += 1,
+        }
+    }
+}
+
+fn report_copy_info(
     term: &Term,
     source: &str,
     destination: &str,
     redacter_options: &Option<RedacterOptions>,
     file_converters: &FileConverters<'_>,
+    styles: &CopyOutputStyles,
 ) -> AppResult<()> {
-    let bold_style = Style::new().bold();
-    let redacted_output = if let Some(ref options) = redacter_options.as_ref() {
-        bold_style
-            .clone()
-            .green()
-            .apply_to(format!("✓ Yes ({})", options))
-    } else {
-        bold_style.clone().red().apply_to("✗ No".to_string())
-    };
-    let sampling_output = if let Some(ref sampling_size) = redacter_options
-        .as_ref()
-        .and_then(|o| o.base_options.sampling_size)
-    {
-        Style::new().apply_to(format!("{sampling_size} bytes."))
-    } else {
-        Style::new().dim().apply_to("-".to_string())
-    };
-
-    let converter_style = Style::new();
-    let pdf_support_output = if file_converters.pdf_image_converter.is_some() {
-        converter_style
-            .clone()
-            .green()
-            .apply_to("✓ Yes".to_string())
-    } else {
-        converter_style.clone().dim().apply_to("✗ No".to_string())
-    };
-
-    let ocr_support_output = if file_converters.ocr.is_some() {
-        converter_style
-            .clone()
-            .green()
-            .apply_to("✓ Yes".to_string())
-    } else {
-        converter_style.clone().dim().apply_to("✗ No".to_string())
+    let capabilities = CopyCapabilities {
+        redacters: redacter_options
+            .as_ref()
+            .map(|options| {
+                options
+                    .provider_options
+                    .iter()
+                    .map(|provider| provider.redacter_type())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        pdf_rendering: file_converters.pdf_image_converter.is_some(),
+        ocr: file_converters.ocr.is_some(),
+        sampling_size: redacter_options
+            .as_ref()
+            .and_then(|o| o.base_options.sampling_size),
     };
 
     term.write_line(
         format!(
-            "Copying from {} to {}.\nRedacting: {}. | Sampling: {} | PDF to image support: {} | OCR support: {}\n",
-            bold_style.clone().white().apply_to(source),
-            bold_style.clone().yellow().apply_to(destination),
-            redacted_output,
-            sampling_output,
-            pdf_support_output,
-            ocr_support_output,
+            "Copying from {} to {}.",
+            styles.highlighted.apply_to(source),
+            Style::new().bold().yellow().apply_to(destination),
         )
         .as_str(),
     )?;
+    term.write_line(format_capabilities_line(&capabilities, styles).as_str())?;
+    term.write_line("")?;
     Ok(())
 }
 
@@ -255,111 +278,6 @@ enum TransferFileResult {
     Copied,
     RedactedAndCopied,
     Skipped,
-}
-
-const PROCESSING_MEDIA_TYPE_WIDTH: usize = 28;
-const PROCESSING_MIN_PATH_WIDTH: usize = 8;
-const PROCESSING_FALLBACK_WIDTH: usize = 80;
-
-/// Truncates `s` to at most `width` display columns, keeping a prefix and a
-/// (slightly longer) suffix joined by a single `…`, so the most identifying
-/// part of a path (its file name) tends to survive. Widths are measured with
-/// `console::measure_text_width` so multi-byte and wide characters are
-/// accounted for rather than counted as one byte each.
-fn truncate_middle(s: &str, width: usize) -> String {
-    if width == 0 {
-        return String::new();
-    }
-    if console::measure_text_width(s) <= width {
-        return s.to_string();
-    }
-    if width == 1 {
-        return "…".to_string();
-    }
-    let budget = width - 1; // reserve one column for the ellipsis
-    let head_budget = budget / 2;
-    let tail_budget = budget - head_budget;
-
-    let chars: Vec<char> = s.chars().collect();
-
-    let mut head = String::new();
-    let mut used = 0;
-    for &c in &chars {
-        let w = console::measure_text_width(&c.to_string());
-        if used + w > head_budget {
-            break;
-        }
-        head.push(c);
-        used += w;
-    }
-
-    let mut tail = String::new();
-    used = 0;
-    for &c in chars.iter().rev() {
-        let w = console::measure_text_width(&c.to_string());
-        if used + w > tail_budget {
-            break;
-        }
-        tail.insert(0, c);
-        used += w;
-    }
-
-    format!("{head}…{tail}")
-}
-
-/// Fits `s` into exactly `width` display columns: pads short values on the
-/// right, and middle-truncates values that overflow.
-fn fit_column(s: &str, width: usize) -> String {
-    if console::measure_text_width(s) <= width {
-        pad_str(s, width, Alignment::Left, None).to_string()
-    } else {
-        truncate_middle(s, width)
-    }
-}
-
-/// Builds the "Processing ... to ... Size: ..." progress line so it fits
-/// within `width` display columns instead of wrapping on its own padding.
-/// The two path columns share whatever room is left after the literal text,
-/// the fixed media-type column and the (unpadded) size column, split evenly
-/// with a sane minimum so narrow terminals degrade to truncated names rather
-/// than zero-width columns.
-fn format_processing_line(
-    width: usize,
-    source_path: &str,
-    destination_path: &str,
-    media_type: &str,
-    size: &str,
-    bold_style: &Style,
-) -> String {
-    let width = if width == 0 {
-        PROCESSING_FALLBACK_WIDTH
-    } else {
-        width
-    };
-
-    let literal_width = console::measure_text_width("Processing ")
-        + console::measure_text_width(" to ")
-        + console::measure_text_width(" ")
-        + console::measure_text_width(" Size: ");
-    let size_width = console::measure_text_width(size);
-
-    let available_for_paths = width
-        .saturating_sub(literal_width)
-        .saturating_sub(PROCESSING_MEDIA_TYPE_WIDTH)
-        .saturating_sub(size_width);
-    let path_width = (available_for_paths / 2).max(PROCESSING_MIN_PATH_WIDTH);
-
-    let source_display = fit_column(source_path, path_width);
-    let destination_display = fit_column(destination_path, path_width);
-    let media_type_display = fit_column(media_type, PROCESSING_MEDIA_TYPE_WIDTH);
-
-    format!(
-        "Processing {} to {} {} Size: {}",
-        bold_style.apply_to(source_display),
-        bold_style.apply_to(destination_display),
-        media_type_display,
-        bold_style.apply_to(size)
-    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -377,17 +295,24 @@ async fn transfer_and_redact_file<
     redacter: &Option<(RedacterBaseOptions, Vec<Redacters<'a>>)>,
     file_converters: &FileConverters<'a>,
     redacter_throttler: &mut Option<RedacterThrottler>,
-) -> AppResult<TransferFileResult> {
-    let bold_style = Style::new().bold().white();
+    styles: &CopyOutputStyles,
+) -> AppResult<TransferReport> {
     let (base_file_ref, source_reader) = source_fs.download(source_file_ref).await?;
 
-    let base_resolved_file_ref = source_fs.resolve(Some(&base_file_ref));
-    match options.file_matcher.matches(&base_file_ref) {
-        FileMatcherResult::SkippedDueToSize | FileMatcherResult::SkippedDueToName => {
-            bar.inc(1);
-            return Ok(TransferFileResult::Skipped);
-        }
-        FileMatcherResult::Matched => {}
+    let skip_reason = match options.file_matcher.matches(&base_file_ref) {
+        FileMatcherResult::SkippedDueToSize => Some(SkipReason::OverSizeLimit),
+        FileMatcherResult::SkippedDueToName => Some(SkipReason::NameFilter),
+        FileMatcherResult::Matched => None,
+    };
+    if let Some(reason) = skip_reason {
+        let outcome = CopyFileOutcome::Skipped { reason };
+        print_file_row(term, bar, &base_file_ref, &outcome, styles);
+        bar.inc(1);
+        return Ok(TransferReport {
+            result: TransferFileResult::Skipped,
+            outcome,
+            file_size: base_file_ref.file_size,
+        });
     }
 
     let file_ref = source_file_ref.unwrap_or(&base_file_ref);
@@ -397,32 +322,16 @@ async fn transfer_and_redact_file<
         media_type: file_ref.media_type.clone(),
         file_size: file_ref.file_size,
     };
-    bar.println(
-        format_processing_line(
-            term.width() as usize,
-            &base_resolved_file_ref.file_path,
-            destination_fs
-                .resolve(Some(&dest_file_ref))
-                .file_path
-                .as_str(),
-            file_ref
-                .media_type
-                .as_ref()
-                .map(|media_type| media_type.to_string())
-                .unwrap_or_else(|| "unknown".to_string())
-                .as_str(),
-            HumanBytes(file_ref.file_size.map(|sz| sz as u64).unwrap_or(0_u64))
-                .to_string()
-                .as_str(),
-            &bold_style,
-        )
-        .as_str(),
+    tracing::debug!(
+        source = %source_fs.resolve(Some(&base_file_ref)).file_path,
+        destination = %destination_fs.resolve(Some(&dest_file_ref)).file_path,
+        "processing a file"
     );
-    let transfer_result = if let Some(ref redacter_with_options) = redacter {
+    let (transfer_result, outcome) = if let Some(ref redacter_with_options) = redacter {
         redact_upload_file::<SFS, DFS, _>(
             bar,
             destination_fs,
-            bold_style,
+            styles,
             source_reader,
             file_ref,
             options,
@@ -435,10 +344,40 @@ async fn transfer_and_redact_file<
         destination_fs
             .upload(source_reader, Some(&dest_file_ref))
             .await?;
-        TransferFileResult::Copied
+        (TransferFileResult::Copied, CopyFileOutcome::Copied)
     };
+    print_file_row(term, bar, file_ref, &outcome, styles);
     bar.inc(1);
-    Ok(transfer_result)
+    Ok(TransferReport {
+        result: transfer_result,
+        outcome,
+        file_size: file_ref.file_size,
+    })
+}
+
+/// Prints the row for a file once its processing has finished.
+fn print_file_row(
+    term: &Term,
+    bar: &ProgressBar,
+    file_ref: &FileSystemRef,
+    outcome: &CopyFileOutcome,
+    styles: &CopyOutputStyles,
+) {
+    bar.println(format_file_row(
+        term.width() as usize,
+        file_ref.relative_path.value(),
+        file_ref
+            .media_type
+            .as_ref()
+            .map(|media_type| media_type.to_string())
+            .unwrap_or_default()
+            .as_str(),
+        HumanBytes(file_ref.file_size.map(|sz| sz as u64).unwrap_or(0_u64))
+            .to_string()
+            .as_str(),
+        outcome,
+        styles,
+    ));
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -450,16 +389,16 @@ async fn redact_upload_file<
 >(
     bar: &ProgressBar,
     destination_fs: &mut DFS,
-    bold_style: Style,
+    styles: &CopyOutputStyles,
     source_reader: S,
     dest_file_ref: &FileSystemRef,
     options: &CopyCommandOptions,
     redacter_with_options: &(RedacterBaseOptions, Vec<Redacters<'a>>),
     file_converters: &FileConverters<'a>,
     redacter_throttler: &mut Option<RedacterThrottler>,
-) -> AppResult<TransferFileResult> {
+) -> AppResult<(TransferFileResult, CopyFileOutcome)> {
     let (redacter_base_options, redacters) = redacter_with_options;
-    let stream_redacter = StreamRedacter::new(redacter_base_options, file_converters, bar);
+    let stream_redacter = StreamRedacter::new(redacter_base_options, file_converters);
 
     let dest_file_ref_overridden = options
         .file_mime_override
@@ -475,14 +414,13 @@ async fn redact_upload_file<
             let delay = throttler.delay();
             if delay.as_millis() > 0 {
                 bar.println(
-                    format!(
-                        "⧗ Delaying redaction for {} seconds",
-                        bold_style
-                            .clone()
-                            .yellow()
-                            .apply_to(throttler.delay().as_secs().to_string())
-                    )
-                    .as_str(),
+                    styles
+                        .dimmed
+                        .apply_to(format!(
+                            "⧗ Delaying redaction for {} seconds",
+                            throttler.delay().as_secs()
+                        ))
+                        .to_string(),
                 );
                 tokio::time::sleep(*delay).await;
             }
@@ -498,65 +436,72 @@ async fn redact_upload_file<
                 destination_fs
                     .upload(redacted_result.stream, Some(dest_file_ref))
                     .await?;
-                if redacted_result.number_of_redactions > 0 {
-                    Ok(TransferFileResult::RedactedAndCopied)
+                let summary = redacted_result.summary;
+                let outcome = if !summary.applied.is_empty() {
+                    CopyFileOutcome::Redacted {
+                        redacters: summary.applied,
+                        conversion: summary.conversion,
+                    }
                 } else {
-                    Ok(TransferFileResult::Copied)
+                    CopyFileOutcome::CopiedUnredacted {
+                        reason: not_redacted_reason(summary.blocked),
+                    }
+                };
+                if redacted_result.number_of_redactions > 0 {
+                    Ok((TransferFileResult::RedactedAndCopied, outcome))
+                } else {
+                    Ok((TransferFileResult::Copied, outcome))
                 }
             }
-            Ok(_) => {
-                bar.println(
-                    format!(
-                        "↲ Skipping redaction because {} redactions were applied",
-                        bold_style.yellow().apply_to("no suitable".to_string())
-                    )
-                    .as_str(),
-                );
-                Ok(TransferFileResult::Skipped)
-            }
+            Ok(redacted_result) => Ok((
+                TransferFileResult::Skipped,
+                CopyFileOutcome::Skipped {
+                    reason: SkipReason::NotRedacted(not_redacted_reason(
+                        redacted_result.summary.blocked,
+                    )),
+                },
+            )),
             Err(ref error) => {
-                bar.println(
-                    format!(
-                        "↲ {}. Skipping due to: {}\n{:?}\n",
-                        bold_style.clone().red().apply_to("Error redacting"),
-                        bold_style.apply_to(error),
-                        error.source()
-                    )
-                    .as_str(),
-                );
-                Ok(TransferFileResult::Skipped)
+                tracing::debug!(error = %error, source = ?error.source(), "redaction failed");
+                Ok((
+                    TransferFileResult::Skipped,
+                    CopyFileOutcome::Error {
+                        message: error.to_string(),
+                    },
+                ))
             }
         }
     } else if redacter_base_options.allow_unsupported_copies {
-        bar.println(
-            format!(
-                "↳ Copying {} because it is explicitly allowed by arguments",
-                bold_style
-                    .clone()
-                    .yellow()
-                    .apply_to("unredacted".to_string())
-            )
-            .as_str(),
-        );
         destination_fs
             .upload(source_reader, Some(dest_file_ref))
             .await?;
-        Ok(TransferFileResult::Copied)
+        Ok((
+            TransferFileResult::Copied,
+            CopyFileOutcome::CopiedUnredacted {
+                reason: NotRedactedReason::TypeNotSupported,
+            },
+        ))
     } else {
-        bar.println(
-            format!(
-                "↲ Skipping redaction because {} media type is not supported",
-                bold_style.apply_to(
-                    dest_file_ref
-                        .media_type
-                        .as_ref()
-                        .map(|mt| mt.to_string())
-                        .unwrap_or("".to_string())
-                )
-            )
-            .as_str(),
-        );
-        Ok(TransferFileResult::Skipped)
+        Ok((
+            TransferFileResult::Skipped,
+            CopyFileOutcome::Skipped {
+                reason: SkipReason::NotRedacted(NotRedactedReason::TypeNotSupported),
+            },
+        ))
+    }
+}
+
+/// Why redaction did not happen, defaulting to "there was nothing left to redact"
+/// when the pipeline did not record a reason.
+fn not_redacted_reason(blocked: Option<crate::redacters::RedactionBlocked>) -> NotRedactedReason {
+    use crate::redacters::RedactionBlocked;
+    match blocked {
+        Some(RedactionBlocked::PdfRendererUnavailable) => NotRedactedReason::PdfRendererUnavailable,
+        Some(RedactionBlocked::OcrUnavailable) => NotRedactedReason::OcrUnavailable,
+        Some(RedactionBlocked::OcrImageFormatNotSupported) => {
+            NotRedactedReason::OcrImageFormatNotSupported
+        }
+        None => NotRedactedReason::AlreadyRedacted,
     }
 }
 
@@ -577,130 +522,6 @@ mod tests {
     const SAMPLE_FILE_NAMES: [&str; 5] = TEST_DOCUMENT_NAMES;
     const SAMPLE_EMAIL: &str = TEST_DOCUMENT_SAMPLE_EMAIL;
     const SAMPLE_PHONE: &str = TEST_DOCUMENT_SAMPLE_PHONE;
-
-    fn plain_style() -> Style {
-        Style::new()
-    }
-
-    #[test]
-    fn processing_line_fits_within_width_with_long_destination() {
-        let destination = "redacted/redacted.zip:documents/customer-profile.html";
-        assert_eq!(console::measure_text_width(destination), 53);
-
-        let line = format_processing_line(
-            150,
-            "documents/customer-profile.html",
-            destination,
-            "text/html",
-            "12.34 KiB",
-            &plain_style(),
-        );
-
-        assert!(
-            console::measure_text_width(&line) <= 150,
-            "line was {} columns wide: {:?}",
-            console::measure_text_width(&line),
-            line
-        );
-        assert!(line.ends_with("12.34 KiB"), "line was: {line:?}");
-        assert_eq!(
-            line,
-            line.trim_end(),
-            "line has trailing whitespace: {line:?}"
-        );
-    }
-
-    #[test]
-    fn processing_line_middle_truncates_long_paths_at_narrow_width() {
-        let source = "documents/very-long-nested-directory-path/a.txt";
-        let destination = "redacted/very-long-nested-directory-path/a.txt";
-
-        let line = format_processing_line(
-            80,
-            source,
-            destination,
-            "text/plain",
-            "1.00 KiB",
-            &plain_style(),
-        );
-
-        assert!(
-            console::measure_text_width(&line) <= 80,
-            "line was {} columns wide: {:?}",
-            console::measure_text_width(&line),
-            line
-        );
-        assert!(line.contains('…'), "line was: {line:?}");
-        // The tail (file name) must survive truncation.
-        assert!(line.contains("a.txt"), "line was: {line:?}");
-    }
-
-    #[test]
-    fn fit_column_pads_short_values_without_truncating() {
-        let result = fit_column("a.txt", 20);
-        assert!(!result.contains('…'), "result was: {result:?}");
-        assert_eq!(console::measure_text_width(&result), 20);
-        assert!(result.starts_with("a.txt"));
-    }
-
-    #[test]
-    fn processing_line_falls_back_to_80_columns_when_width_is_zero() {
-        // Short enough that whether the path column is computed from a
-        // width of 0 or of 80 changes how much padding trails it, so a
-        // missing width == 0 fallback shows up as a mismatch here.
-        let line_zero = format_processing_line(
-            0,
-            "src.txt",
-            "dst.txt",
-            "text/plain",
-            "1.00 KiB",
-            &plain_style(),
-        );
-        let line_eighty = format_processing_line(
-            80,
-            "src.txt",
-            "dst.txt",
-            "text/plain",
-            "1.00 KiB",
-            &plain_style(),
-        );
-        assert_eq!(line_zero, line_eighty);
-    }
-
-    #[test]
-    fn truncate_middle_measures_multibyte_characters_by_display_width() {
-        let source = "documents/café-résumé-naïve-longer-file-name.txt";
-        // Every character in this path is 1 display column wide (no CJK),
-        // so display width differs from byte length but not from char count.
-        assert!(source.len() > source.chars().count());
-
-        let truncated = truncate_middle(source, 20);
-        assert_eq!(console::measure_text_width(&truncated), 20);
-        assert!(truncated.contains('…'));
-
-        let wide = "文档/非常长的中文文件名称示例说明.txt";
-        let truncated_wide = truncate_middle(wide, 20);
-        assert!(console::measure_text_width(&truncated_wide) <= 20);
-        assert!(truncated_wide.contains('…'));
-    }
-
-    #[test]
-    fn processing_line_truncates_media_type_longer_than_28_columns() {
-        let media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-        assert!(console::measure_text_width(media_type) > 28);
-
-        let line = format_processing_line(
-            150,
-            "documents/source.txt",
-            "redacted/destination.txt",
-            media_type,
-            "1.00 KiB",
-            &plain_style(),
-        );
-
-        assert!(line.contains('…'), "line was: {line:?}");
-        assert!(!line.contains(media_type), "line was: {line:?}");
-    }
 
     fn base_redacter_options(provider_options: RedacterProviderOptions) -> RedacterOptions {
         RedacterOptions {

--- a/src/commands/copy_output.rs
+++ b/src/commands/copy_output.rs
@@ -1,0 +1,829 @@
+//! Rendering of the `cp` command's terminal output: the capabilities line, the
+//! legend, one row per file and the closing summary.
+//!
+//! Everything here is pure: it takes what happened to a file and returns the
+//! line to print, so the layout is unit tested without running a copy.
+
+use crate::args::RedacterType;
+use crate::redacters::RedactionConversion;
+use console::{pad_str, Alignment, Style};
+
+/// Why a file was copied without being redacted, or skipped instead of redacted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotRedactedReason {
+    /// No configured redacter supports the file's media type.
+    TypeNotSupported,
+    /// The redaction pipeline applied no redaction step: there was nothing suitable
+    /// to redact in the file, so its content is left as it is.
+    AlreadyRedacted,
+    /// The file is a PDF and the PDF renderer is not available in this build.
+    PdfRendererUnavailable,
+    /// Redaction needs the OCR engine and it is not available in this build.
+    OcrUnavailable,
+    /// The OCR engine cannot read the image format of the file.
+    OcrImageFormatNotSupported,
+}
+
+/// Why a file was not copied at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipReason {
+    /// The file is larger than `--max-size-limit`.
+    OverSizeLimit,
+    /// The file name does not match `--filename-filter`.
+    NameFilter,
+    /// Redaction did not apply and unsupported copies are not allowed.
+    NotRedacted(NotRedactedReason),
+}
+
+/// What happened to a single file, as the row for it is printed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CopyFileOutcome {
+    /// Redacted by the listed redacters and copied.
+    Redacted {
+        redacters: Vec<RedacterType>,
+        conversion: Option<RedactionConversion>,
+    },
+    /// Copied unchanged because no redacter was configured.
+    Copied,
+    /// Copied unchanged although a redacter was configured, because
+    /// `--allow-unsupported-copies` is set.
+    CopiedUnredacted { reason: NotRedactedReason },
+    /// Not copied at all.
+    Skipped { reason: SkipReason },
+    /// Redaction failed, so the file was not copied.
+    Error { message: String },
+}
+
+/// The glyph that carries the outcome in the first column of a row.
+const GLYPH_REDACTED: &str = "✓";
+const GLYPH_COPIED: &str = "→";
+const GLYPH_SKIPPED: &str = "↷";
+const GLYPH_ERROR: &str = "✗";
+
+const MEDIA_TYPE_WIDTH: usize = 24;
+const SIZE_WIDTH: usize = 10;
+const MIN_FILENAME_WIDTH: usize = 12;
+const MIN_DETAIL_WIDTH: usize = 20;
+const MAX_DETAIL_WIDTH: usize = 40;
+const FALLBACK_TERMINAL_WIDTH: usize = 80;
+
+/// Styles used by the `cp` output, kept together so tests can render the same
+/// lines without any styling at all.
+#[derive(Debug, Clone)]
+pub struct CopyOutputStyles {
+    pub filename: Style,
+    pub media_type: Style,
+    pub size: Style,
+    pub redacted: Style,
+    pub copied: Style,
+    pub skipped: Style,
+    pub error: Style,
+    pub dimmed: Style,
+    pub highlighted: Style,
+}
+
+impl CopyOutputStyles {
+    pub fn new() -> Self {
+        Self {
+            filename: Style::new().bold().white(),
+            media_type: Style::new(),
+            size: Style::new().bold(),
+            redacted: Style::new().green(),
+            copied: Style::new(),
+            skipped: Style::new().dim().yellow(),
+            error: Style::new().red(),
+            dimmed: Style::new().dim(),
+            highlighted: Style::new().bold().white(),
+        }
+    }
+
+    #[cfg(test)]
+    fn plain() -> Self {
+        Self {
+            filename: Style::new(),
+            media_type: Style::new(),
+            size: Style::new(),
+            redacted: Style::new(),
+            copied: Style::new(),
+            skipped: Style::new(),
+            error: Style::new(),
+            dimmed: Style::new(),
+            highlighted: Style::new(),
+        }
+    }
+}
+
+impl Default for CopyOutputStyles {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// What the redacters and converters available for this run can do, as shown in
+/// the header of the command.
+#[derive(Debug, Clone)]
+pub struct CopyCapabilities {
+    pub redacters: Vec<RedacterType>,
+    pub pdf_rendering: bool,
+    pub ocr: bool,
+    pub sampling_size: Option<usize>,
+}
+
+/// The counts and the size shown in the closing summary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CopySummary {
+    pub redacted: usize,
+    pub copied_as_is: usize,
+    pub skipped: usize,
+    pub errors: usize,
+    pub total_size: u64,
+}
+
+impl CopyFileOutcome {
+    fn glyph(&self) -> &'static str {
+        match self {
+            CopyFileOutcome::Redacted { .. } => GLYPH_REDACTED,
+            CopyFileOutcome::Copied | CopyFileOutcome::CopiedUnredacted { .. } => GLYPH_COPIED,
+            CopyFileOutcome::Skipped { .. } => GLYPH_SKIPPED,
+            CopyFileOutcome::Error { .. } => GLYPH_ERROR,
+        }
+    }
+
+    fn style<'a>(&self, styles: &'a CopyOutputStyles) -> &'a Style {
+        match self {
+            CopyFileOutcome::Redacted { .. } => &styles.redacted,
+            CopyFileOutcome::Copied | CopyFileOutcome::CopiedUnredacted { .. } => &styles.copied,
+            CopyFileOutcome::Skipped { .. } => &styles.skipped,
+            CopyFileOutcome::Error { .. } => &styles.error,
+        }
+    }
+}
+
+impl NotRedactedReason {
+    fn detail(&self) -> &'static str {
+        match self {
+            NotRedactedReason::TypeNotSupported => "type not supported",
+            NotRedactedReason::AlreadyRedacted => "already redacted",
+            NotRedactedReason::PdfRendererUnavailable => "pdf renderer unavailable",
+            NotRedactedReason::OcrUnavailable => "ocr unavailable",
+            NotRedactedReason::OcrImageFormatNotSupported => "ocr: image format not supported",
+        }
+    }
+}
+
+impl SkipReason {
+    fn detail(&self) -> &'static str {
+        match self {
+            SkipReason::OverSizeLimit => "over size limit",
+            SkipReason::NameFilter => "name filter",
+            SkipReason::NotRedacted(reason) => reason.detail(),
+        }
+    }
+}
+
+/// The detail column of a row: what the glyph does not already say.
+pub fn format_outcome_detail(outcome: &CopyFileOutcome) -> String {
+    match outcome {
+        CopyFileOutcome::Redacted {
+            redacters,
+            conversion,
+        } => {
+            let mut parts: Vec<String> = redacters.iter().map(|r| r.to_string()).collect();
+            match conversion {
+                Some(RedactionConversion::PdfToImages { pages, ocr }) => {
+                    parts.push(format!(
+                        "pdf → {pages} {}",
+                        if *pages == 1 { "image" } else { "images" }
+                    ));
+                    if *ocr {
+                        parts.push("ocr".to_string());
+                    }
+                }
+                Some(RedactionConversion::Ocr) => parts.push("ocr".to_string()),
+                None => {}
+            }
+            parts.join(", ")
+        }
+        CopyFileOutcome::Copied => String::new(),
+        CopyFileOutcome::CopiedUnredacted { reason } => reason.detail().to_string(),
+        CopyFileOutcome::Skipped { reason } => reason.detail().to_string(),
+        CopyFileOutcome::Error { message } => message.clone(),
+    }
+}
+
+/// The widths of the four columns of a row, derived from the terminal width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RowLayout {
+    filename: usize,
+    media_type: usize,
+    size: usize,
+    detail: usize,
+}
+
+fn row_layout(terminal_width: usize) -> RowLayout {
+    let terminal_width = if terminal_width == 0 {
+        FALLBACK_TERMINAL_WIDTH
+    } else {
+        terminal_width
+    };
+    // The glyph and its trailing space, plus one space between each pair of columns.
+    let fixed = 2 + 3 + MEDIA_TYPE_WIDTH + SIZE_WIDTH;
+    let available = terminal_width.saturating_sub(fixed);
+    let mut detail = (available / 3).clamp(MIN_DETAIL_WIDTH, MAX_DETAIL_WIDTH);
+    if available.saturating_sub(detail) < MIN_FILENAME_WIDTH {
+        detail = available.saturating_sub(MIN_FILENAME_WIDTH);
+    }
+    let filename = available.saturating_sub(detail).max(MIN_FILENAME_WIDTH);
+    RowLayout {
+        filename,
+        media_type: MEDIA_TYPE_WIDTH,
+        size: SIZE_WIDTH,
+        detail,
+    }
+}
+
+/// Truncates `s` to at most `width` display columns, keeping a prefix and a
+/// (slightly longer) suffix joined by a single `…`, so the most identifying
+/// part of a path (its file name) tends to survive. Widths are measured with
+/// `console::measure_text_width` so multi-byte and wide characters are
+/// accounted for rather than counted as one byte each.
+fn truncate_middle(s: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if console::measure_text_width(s) <= width {
+        return s.to_string();
+    }
+    if width == 1 {
+        return "…".to_string();
+    }
+    let budget = width - 1; // reserve one column for the ellipsis
+    let head_budget = budget / 2;
+    let tail_budget = budget - head_budget;
+
+    let chars: Vec<char> = s.chars().collect();
+
+    let mut head = String::new();
+    let mut used = 0;
+    for &c in &chars {
+        let w = console::measure_text_width(&c.to_string());
+        if used + w > head_budget {
+            break;
+        }
+        head.push(c);
+        used += w;
+    }
+
+    let mut tail = String::new();
+    used = 0;
+    for &c in chars.iter().rev() {
+        let w = console::measure_text_width(&c.to_string());
+        if used + w > tail_budget {
+            break;
+        }
+        tail.insert(0, c);
+        used += w;
+    }
+
+    format!("{head}…{tail}")
+}
+
+/// Truncates `s` to at most `width` display columns, keeping its beginning,
+/// which is what matters for a media type or an error message.
+fn truncate_end(s: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if console::measure_text_width(s) <= width {
+        return s.to_string();
+    }
+    if width == 1 {
+        return "…".to_string();
+    }
+    let budget = width - 1;
+    let mut head = String::new();
+    let mut used = 0;
+    for c in s.chars() {
+        let w = console::measure_text_width(&c.to_string());
+        if used + w > budget {
+            break;
+        }
+        head.push(c);
+        used += w;
+    }
+    format!("{head}…")
+}
+
+/// Fits `s` into exactly `width` display columns: pads short values on the
+/// right, and middle-truncates values that overflow.
+fn fit_column(s: &str, width: usize) -> String {
+    if console::measure_text_width(s) <= width {
+        pad_str(s, width, Alignment::Left, None).to_string()
+    } else {
+        truncate_middle(s, width)
+    }
+}
+
+/// Same as [`fit_column`], keeping the beginning of an overflowing value.
+fn fit_column_head(s: &str, width: usize) -> String {
+    if console::measure_text_width(s) <= width {
+        pad_str(s, width, Alignment::Left, None).to_string()
+    } else {
+        truncate_end(s, width)
+    }
+}
+
+/// The legend printed once, before the first row.
+pub fn format_legend(styles: &CopyOutputStyles) -> String {
+    styles
+        .dimmed
+        .apply_to(format!(
+            "{GLYPH_REDACTED} redacted   {GLYPH_COPIED} copied as is   \
+             {GLYPH_SKIPPED} skipped   {GLYPH_ERROR} error"
+        ))
+        .to_string()
+}
+
+/// One row of the table, written when a file's processing finishes.
+pub fn format_file_row(
+    terminal_width: usize,
+    filename: &str,
+    media_type: &str,
+    size: &str,
+    outcome: &CopyFileOutcome,
+    styles: &CopyOutputStyles,
+) -> String {
+    let layout = row_layout(terminal_width);
+    let outcome_style = outcome.style(styles);
+    let detail = format_outcome_detail(outcome);
+    let detail = truncate_end(&detail, layout.detail);
+
+    let mut row = format!(
+        "{} {} {} ",
+        outcome_style.apply_to(outcome.glyph()),
+        styles
+            .filename
+            .apply_to(fit_column(filename, layout.filename)),
+        styles
+            .media_type
+            .apply_to(fit_column_head(media_type, layout.media_type)),
+    );
+    if detail.is_empty() {
+        row.push_str(&styles.size.apply_to(size).to_string());
+    } else {
+        row.push_str(
+            &styles
+                .size
+                .apply_to(fit_column(size, layout.size))
+                .to_string(),
+        );
+        row.push(' ');
+        row.push_str(&outcome_style.apply_to(detail).to_string());
+    }
+    row.trim_end().to_string()
+}
+
+/// The header line describing what this run can do.
+pub fn format_capabilities_line(
+    capabilities: &CopyCapabilities,
+    styles: &CopyOutputStyles,
+) -> String {
+    let redacting = if capabilities.redacters.is_empty() {
+        styles.dimmed.apply_to("no".to_string())
+    } else {
+        styles.redacted.apply_to(
+            capabilities
+                .redacters
+                .iter()
+                .map(|r| r.to_string())
+                .collect::<Vec<String>>()
+                .join(", "),
+        )
+    };
+    let yes_no = |enabled: bool| {
+        if enabled {
+            styles.redacted.apply_to("yes".to_string())
+        } else {
+            styles.dimmed.apply_to("no".to_string())
+        }
+    };
+    let sampling = match capabilities.sampling_size {
+        Some(size) => styles.highlighted.apply_to(format!("{size} bytes")),
+        None => styles.dimmed.apply_to("off".to_string()),
+    };
+    format!(
+        "Redacting: {} · PDF rendering: {} · OCR: {} · Sampling: {}",
+        redacting,
+        yes_no(capabilities.pdf_rendering),
+        yes_no(capabilities.ocr),
+        sampling
+    )
+}
+
+/// The closing summary, replacing the per-file step lines with one count line.
+pub fn format_summary_line(summary: &CopySummary, styles: &CopyOutputStyles) -> String {
+    let total = summary.redacted + summary.copied_as_is + summary.skipped + summary.errors;
+    let mut line = format!(
+        "{} {}: {} redacted, {} copied as is, {} skipped",
+        styles.highlighted.apply_to(total),
+        if total == 1 { "file" } else { "files" },
+        styles.highlighted.apply_to(summary.redacted),
+        styles.highlighted.apply_to(summary.copied_as_is),
+        styles.highlighted.apply_to(summary.skipped),
+    );
+    if summary.errors > 0 {
+        line.push_str(
+            format!(
+                ", {} {}",
+                styles.error.apply_to(summary.errors),
+                if summary.errors == 1 {
+                    "error"
+                } else {
+                    "errors"
+                }
+            )
+            .as_str(),
+        );
+    }
+    line.push_str(
+        format!(
+            ". Total size: {}",
+            styles
+                .highlighted
+                .apply_to(indicatif::HumanBytes(summary.total_size))
+        )
+        .as_str(),
+    );
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(
+        width: usize,
+        filename: &str,
+        media_type: &str,
+        size: &str,
+        outcome: &CopyFileOutcome,
+    ) -> String {
+        format_file_row(
+            width,
+            filename,
+            media_type,
+            size,
+            outcome,
+            &CopyOutputStyles::plain(),
+        )
+    }
+
+    fn redacted(
+        redacters: &[RedacterType],
+        conversion: Option<RedactionConversion>,
+    ) -> CopyFileOutcome {
+        CopyFileOutcome::Redacted {
+            redacters: redacters.to_vec(),
+            conversion,
+        }
+    }
+
+    #[test]
+    fn outcome_detail_renders_every_variant() {
+        assert_eq!(
+            format_outcome_detail(&redacted(&[RedacterType::GcpDlp], None)),
+            "gcp-dlp"
+        );
+        assert_eq!(
+            format_outcome_detail(&redacted(
+                &[RedacterType::GcpDlp, RedacterType::AwsComprehend],
+                None
+            )),
+            "gcp-dlp, aws-comprehend"
+        );
+        assert_eq!(
+            format_outcome_detail(&redacted(
+                &[RedacterType::GcpDlp],
+                Some(RedactionConversion::PdfToImages {
+                    pages: 3,
+                    ocr: false
+                })
+            )),
+            "gcp-dlp, pdf → 3 images"
+        );
+        assert_eq!(
+            format_outcome_detail(&redacted(
+                &[RedacterType::GcpDlp],
+                Some(RedactionConversion::PdfToImages {
+                    pages: 1,
+                    ocr: false
+                })
+            )),
+            "gcp-dlp, pdf → 1 image"
+        );
+        assert_eq!(
+            format_outcome_detail(&redacted(
+                &[RedacterType::GcpDlp],
+                Some(RedactionConversion::PdfToImages {
+                    pages: 2,
+                    ocr: true
+                })
+            )),
+            "gcp-dlp, pdf → 2 images, ocr"
+        );
+        assert_eq!(
+            format_outcome_detail(&redacted(
+                &[RedacterType::GcpDlp],
+                Some(RedactionConversion::Ocr)
+            )),
+            "gcp-dlp, ocr"
+        );
+        assert_eq!(format_outcome_detail(&CopyFileOutcome::Copied), "");
+        assert_eq!(
+            format_outcome_detail(&CopyFileOutcome::CopiedUnredacted {
+                reason: NotRedactedReason::TypeNotSupported
+            }),
+            "type not supported"
+        );
+        for (reason, expected) in [
+            (SkipReason::OverSizeLimit, "over size limit"),
+            (SkipReason::NameFilter, "name filter"),
+            (
+                SkipReason::NotRedacted(NotRedactedReason::TypeNotSupported),
+                "type not supported",
+            ),
+            (
+                SkipReason::NotRedacted(NotRedactedReason::AlreadyRedacted),
+                "already redacted",
+            ),
+            (
+                SkipReason::NotRedacted(NotRedactedReason::PdfRendererUnavailable),
+                "pdf renderer unavailable",
+            ),
+            (
+                SkipReason::NotRedacted(NotRedactedReason::OcrUnavailable),
+                "ocr unavailable",
+            ),
+            (
+                SkipReason::NotRedacted(NotRedactedReason::OcrImageFormatNotSupported),
+                "ocr: image format not supported",
+            ),
+        ] {
+            assert_eq!(
+                format_outcome_detail(&CopyFileOutcome::Skipped { reason }),
+                expected
+            );
+        }
+        assert_eq!(
+            format_outcome_detail(&CopyFileOutcome::Error {
+                message: "invalid JSON at line 1".to_string()
+            }),
+            "invalid JSON at line 1"
+        );
+    }
+
+    #[test]
+    fn row_starts_with_the_glyph_of_its_outcome() {
+        let cases = [
+            (redacted(&[RedacterType::GcpDlp], None), '✓'),
+            (CopyFileOutcome::Copied, '→'),
+            (
+                CopyFileOutcome::CopiedUnredacted {
+                    reason: NotRedactedReason::TypeNotSupported,
+                },
+                '→',
+            ),
+            (
+                CopyFileOutcome::Skipped {
+                    reason: SkipReason::NameFilter,
+                },
+                '↷',
+            ),
+            (
+                CopyFileOutcome::Error {
+                    message: "boom".to_string(),
+                },
+                '✗',
+            ),
+        ];
+        for (outcome, glyph) in cases {
+            let line = row(100, "documents/a.txt", "text/plain", "1.00 KiB", &outcome);
+            assert_eq!(
+                line.chars().next(),
+                Some(glyph),
+                "row was: {line:?} for {outcome:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rows_fit_the_terminal_width_and_keep_the_file_name_tail() {
+        let filename = "documents/very-long-nested-directory-path/customer-profile.html";
+        let outcome = redacted(
+            &[RedacterType::GcpDlp, RedacterType::AwsComprehend],
+            Some(RedactionConversion::PdfToImages {
+                pages: 12,
+                ocr: true,
+            }),
+        );
+        for width in [80, 100, 150] {
+            let line = row(
+                width,
+                filename,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "12.34 KiB",
+                &outcome,
+            );
+            assert!(
+                console::measure_text_width(&line) <= width,
+                "row at {width} columns was {} wide: {line:?}",
+                console::measure_text_width(&line)
+            );
+            assert_eq!(line, line.trim_end(), "row has trailing spaces: {line:?}");
+            assert!(
+                line.contains("file.html"),
+                "row at {width} lost the file name tail: {line:?}"
+            );
+        }
+        // A wide terminal keeps the whole path rather than only its tail.
+        let wide_line = row(
+            150,
+            filename,
+            "text/html",
+            "12.34 KiB",
+            &CopyFileOutcome::Copied,
+        );
+        assert!(wide_line.contains(filename), "row was: {wide_line:?}");
+    }
+
+    #[test]
+    fn a_row_without_a_detail_has_no_trailing_padding() {
+        let line = row(
+            100,
+            "a.txt",
+            "text/plain",
+            "1.00 KiB",
+            &CopyFileOutcome::Copied,
+        );
+        assert!(line.ends_with("1.00 KiB"), "row was: {line:?}");
+    }
+
+    #[test]
+    fn narrow_rows_still_render_every_column() {
+        let line = row(
+            80,
+            "documents/customer-note.txt",
+            "text/plain",
+            "1.00 KiB",
+            &CopyFileOutcome::Skipped {
+                reason: SkipReason::OverSizeLimit,
+            },
+        );
+        assert!(line.contains("text/plain"), "row was: {line:?}");
+        assert!(line.contains("1.00 KiB"), "row was: {line:?}");
+        assert!(line.contains("over size limit"), "row was: {line:?}");
+    }
+
+    #[test]
+    fn legend_names_every_glyph_once() {
+        let legend = format_legend(&CopyOutputStyles::plain());
+        assert_eq!(legend, "✓ redacted   → copied as is   ↷ skipped   ✗ error");
+    }
+
+    #[test]
+    fn capabilities_line_shows_what_is_on_and_off() {
+        let styles = CopyOutputStyles::plain();
+        assert_eq!(
+            format_capabilities_line(
+                &CopyCapabilities {
+                    redacters: vec![RedacterType::GcpDlp],
+                    pdf_rendering: true,
+                    ocr: false,
+                    sampling_size: None,
+                },
+                &styles
+            ),
+            "Redacting: gcp-dlp · PDF rendering: yes · OCR: no · Sampling: off"
+        );
+        assert_eq!(
+            format_capabilities_line(
+                &CopyCapabilities {
+                    redacters: vec![],
+                    pdf_rendering: false,
+                    ocr: true,
+                    sampling_size: Some(1024),
+                },
+                &styles
+            ),
+            "Redacting: no · PDF rendering: no · OCR: yes · Sampling: 1024 bytes"
+        );
+        assert_eq!(
+            format_capabilities_line(
+                &CopyCapabilities {
+                    redacters: vec![RedacterType::GcpDlp, RedacterType::AwsComprehend],
+                    pdf_rendering: true,
+                    ocr: true,
+                    sampling_size: None,
+                },
+                &styles
+            ),
+            "Redacting: gcp-dlp, aws-comprehend · PDF rendering: yes · OCR: yes · Sampling: off"
+        );
+    }
+
+    #[test]
+    fn summary_line_counts_files_and_only_mentions_errors_when_there_are_any() {
+        let styles = CopyOutputStyles::plain();
+        assert_eq!(
+            format_summary_line(
+                &CopySummary {
+                    redacted: 3,
+                    copied_as_is: 1,
+                    skipped: 1,
+                    errors: 1,
+                    total_size: 6 * 1024,
+                },
+                &styles
+            ),
+            "6 files: 3 redacted, 1 copied as is, 1 skipped, 1 error. Total size: 6.00 KiB"
+        );
+        assert_eq!(
+            format_summary_line(
+                &CopySummary {
+                    redacted: 5,
+                    copied_as_is: 0,
+                    skipped: 1,
+                    errors: 0,
+                    total_size: 0,
+                },
+                &styles
+            ),
+            "6 files: 5 redacted, 0 copied as is, 1 skipped. Total size: 0 B"
+        );
+        assert_eq!(
+            format_summary_line(
+                &CopySummary {
+                    redacted: 0,
+                    copied_as_is: 1,
+                    skipped: 0,
+                    errors: 0,
+                    total_size: 12,
+                },
+                &styles
+            ),
+            "1 file: 0 redacted, 1 copied as is, 0 skipped. Total size: 12 B"
+        );
+        assert_eq!(
+            format_summary_line(
+                &CopySummary {
+                    redacted: 0,
+                    copied_as_is: 0,
+                    skipped: 0,
+                    errors: 2,
+                    total_size: 0,
+                },
+                &styles
+            ),
+            "2 files: 0 redacted, 0 copied as is, 0 skipped, 2 errors. Total size: 0 B"
+        );
+    }
+
+    #[test]
+    fn truncate_middle_measures_multibyte_characters_by_display_width() {
+        let source = "documents/café-résumé-naïve-longer-file-name.txt";
+        // Every character in this path is 1 display column wide (no CJK),
+        // so display width differs from byte length but not from char count.
+        assert!(source.len() > source.chars().count());
+
+        let truncated = truncate_middle(source, 20);
+        assert_eq!(console::measure_text_width(&truncated), 20);
+        assert!(truncated.contains('…'));
+
+        let wide = "文档/非常长的中文文件名称示例说明.txt";
+        let truncated_wide = truncate_middle(wide, 20);
+        assert!(console::measure_text_width(&truncated_wide) <= 20);
+        assert!(truncated_wide.contains('…'));
+    }
+
+    #[test]
+    fn fit_column_pads_short_values_without_truncating() {
+        let result = fit_column("a.txt", 20);
+        assert!(!result.contains('…'), "result was: {result:?}");
+        assert_eq!(console::measure_text_width(&result), 20);
+        assert!(result.starts_with("a.txt"));
+    }
+
+    #[test]
+    fn media_type_column_keeps_the_beginning_when_it_overflows() {
+        let media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+        let fitted = fit_column_head(media_type, MEDIA_TYPE_WIDTH);
+        assert_eq!(console::measure_text_width(&fitted), MEDIA_TYPE_WIDTH);
+        assert!(fitted.starts_with("application/vnd."), "was: {fitted:?}");
+        assert!(fitted.ends_with('…'), "was: {fitted:?}");
+    }
+
+    #[test]
+    fn row_layout_falls_back_to_80_columns_when_the_width_is_unknown() {
+        assert_eq!(row_layout(0), row_layout(80));
+    }
+}

--- a/src/commands/copy_output.rs
+++ b/src/commands/copy_output.rs
@@ -13,9 +13,9 @@ use console::{pad_str, Alignment, Style};
 pub enum NotRedactedReason {
     /// No configured redacter supports the file's media type.
     TypeNotSupported,
-    /// The redaction pipeline applied no redaction step: there was nothing suitable
-    /// to redact in the file, so its content is left as it is.
-    AlreadyRedacted,
+    /// The redaction pipeline ran no redacter for the file, so its content is left
+    /// as it is.
+    NoRedacterApplied,
     /// The file is a PDF and the PDF renderer is not available in this build.
     PdfRendererUnavailable,
     /// Redaction needs the OCR engine and it is not available in this build.
@@ -163,7 +163,7 @@ impl NotRedactedReason {
     fn detail(&self) -> &'static str {
         match self {
             NotRedactedReason::TypeNotSupported => "type not supported",
-            NotRedactedReason::AlreadyRedacted => "already redacted",
+            NotRedactedReason::NoRedacterApplied => "no redacter applied",
             NotRedactedReason::PdfRendererUnavailable => "pdf renderer unavailable",
             NotRedactedReason::OcrUnavailable => "ocr unavailable",
             NotRedactedReason::OcrImageFormatNotSupported => "ocr: image format not supported",
@@ -553,8 +553,8 @@ mod tests {
                 "type not supported",
             ),
             (
-                SkipReason::NotRedacted(NotRedactedReason::AlreadyRedacted),
-                "already redacted",
+                SkipReason::NotRedacted(NotRedactedReason::NoRedacterApplied),
+                "no redacter applied",
             ),
             (
                 SkipReason::NotRedacted(NotRedactedReason::PdfRendererUnavailable),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,7 @@
 mod copy_command;
 pub use copy_command::*;
 
+mod copy_output;
+
 mod ls_command;
 pub use ls_command::*;

--- a/src/file_systems/aws_s3.rs
+++ b/src/file_systems/aws_s3.rs
@@ -206,10 +206,10 @@ impl<'a> FileSystemConnection<'a> for AwsS3FileSystem<'a> {
         file_matcher: Option<&FileMatcher>,
         max_files_limit: Option<usize>,
     ) -> AppResult<ListFilesResult> {
-        self.reporter.report(format!(
+        self.reporter.report_debug(format!(
             "Listing files in bucket: {} with prefix: {}",
             self.bucket_name, self.object_name
-        ))?;
+        ));
         if self.object_name.ends_with('/') {
             self.list_files_recursively(
                 if self.object_name == "/" {

--- a/src/file_systems/gcs.rs
+++ b/src/file_systems/gcs.rs
@@ -354,10 +354,10 @@ impl<'a> FileSystemConnection<'a> for GoogleCloudStorageFileSystem<'a> {
         file_matcher: Option<&FileMatcher>,
         max_files_limit: Option<usize>,
     ) -> AppResult<ListFilesResult> {
-        self.reporter.report(format!(
+        self.reporter.report_debug(format!(
             "Listing files in bucket: {} with prefix: {}",
             self.bucket_resource_name, self.object_name
-        ))?;
+        ));
         if self.object_name.ends_with('/') {
             let prefix = if self.object_name != "/" {
                 Some(self.object_name.clone())

--- a/src/file_systems/local.rs
+++ b/src/file_systems/local.rs
@@ -144,7 +144,7 @@ impl<'a> FileSystemConnection<'a> for LocalFileSystem<'a> {
         max_files_limit: Option<usize>,
     ) -> AppResult<ListFilesResult> {
         self.reporter
-            .report(format!("Listing files in dir: {}", self.root_path.as_str()))?;
+            .report_debug(format!("Listing files in dir: {}", self.root_path.as_str()));
         let source = PathBuf::from(self.root_path.as_str());
         let source_str = source.to_string_lossy().to_string();
         self.list_files_recursive(source_str.clone(), &file_matcher, max_files_limit)

--- a/src/file_systems/zip.rs
+++ b/src/file_systems/zip.rs
@@ -54,7 +54,7 @@ impl<'a> ZipFileSystem<'a> {
             archive.extract(temp_dir.path())?;
             let temp_dir_str = temp_dir.path().to_string_lossy();
             self.reporter
-                .report(format!("Extracting files to temp dir: {temp_dir_str}"))?;
+                .report_debug(format!("Extracting files to temp dir: {temp_dir_str}"));
             let temp_file_system =
                 LocalFileSystem::new(temp_dir_str.as_ref(), self.reporter).await?;
             self.mode = Some(ZipFileSystemMode::Read {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,20 @@ pub fn config_env_var(name: &str) -> Result<String, String> {
     std::env::var(name).map_err(|e| format!("{name}: {e}"))
 }
 
+/// Sends the internal progress detail to `tracing`, off unless `RUST_LOG` asks for it
+/// (`RUST_LOG=debug` shows what the command is doing behind its table).
+fn init_tracing() {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("off"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init();
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_tracing();
     let term = Term::stdout();
     let bold_style = Style::new().bold();
 
@@ -105,23 +117,6 @@ async fn handle_args(cli: CliArgs, term: &Term) -> AppResult<()> {
                     .as_str(),
                 )?;
             }
-            term.write_line(
-                format!(
-                    "Finished: {} -> {}\nCopied: {}. Redacted: {}. Skipped: {}.",
-                    Style::new().bold().apply_to(source),
-                    Style::new().green().apply_to(destination),
-                    Style::new()
-                        .bold()
-                        .green()
-                        .apply_to(copy_result.files_copied),
-                    Style::new()
-                        .bold()
-                        .green()
-                        .apply_to(copy_result.files_redacted),
-                    Style::new().yellow().apply_to(copy_result.files_skipped),
-                )
-                .as_str(),
-            )?;
         }
         CliCommand::Ls {
             source,

--- a/src/redacters/mod.rs
+++ b/src/redacters/mod.rs
@@ -290,10 +290,10 @@ where
             match native(input).await {
                 Ok(redacted) => coords(redacted).await,
                 Err(err) if should_fall_back_to_coords(mode, err.failure) => {
-                    reporter.report(format!(
+                    reporter.report_debug(format!(
                         "Native image redaction is not available ({}). Falling back to redacting by coordinates.",
                         err.error
-                    ))?;
+                    ));
                     coords(fallback_input).await
                 }
                 Err(err) => Err(err.error),
@@ -363,23 +363,28 @@ pub enum RedacterProviderOptions {
     AwsBedrockGuardrails(AwsBedrockGuardrailsRedacterOptions),
 }
 
+impl RedacterProviderOptions {
+    /// The redacter these options configure, so the type is named in exactly one place.
+    pub fn redacter_type(&self) -> RedacterType {
+        match self {
+            RedacterProviderOptions::GcpDlp(_) => RedacterType::GcpDlp,
+            RedacterProviderOptions::AwsComprehend(_) => RedacterType::AwsComprehend,
+            RedacterProviderOptions::MsPresidio(_) => RedacterType::MsPresidio,
+            RedacterProviderOptions::GeminiLlm(_) => RedacterType::GeminiLlm,
+            RedacterProviderOptions::OpenAiLlm(_) => RedacterType::OpenAiLlm,
+            RedacterProviderOptions::GcpVertexAi(_) => RedacterType::GcpVertexAi,
+            RedacterProviderOptions::AwsBedrock(_) => RedacterType::AwsBedrock,
+            RedacterProviderOptions::AwsBedrockGuardrails(_) => RedacterType::AwsBedrockGuardrails,
+        }
+    }
+}
+
 impl Display for RedacterOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let to_display = self
             .provider_options
             .iter()
-            .map(|o| match o {
-                RedacterProviderOptions::GcpDlp(_) => "gcp-dlp".to_string(),
-                RedacterProviderOptions::AwsComprehend(_) => "aws-comprehend".to_string(),
-                RedacterProviderOptions::MsPresidio(_) => "ms-presidio".to_string(),
-                RedacterProviderOptions::GeminiLlm(_) => "gemini-llm".to_string(),
-                RedacterProviderOptions::OpenAiLlm(_) => "open-ai-llm".to_string(),
-                RedacterProviderOptions::GcpVertexAi(_) => "gcp-vertex-ai".to_string(),
-                RedacterProviderOptions::AwsBedrock(_) => "aws-bedrock".to_string(),
-                RedacterProviderOptions::AwsBedrockGuardrails(_) => {
-                    "aws-bedrock-guardrails".to_string()
-                }
-            })
+            .map(|o| o.redacter_type().to_string())
             .collect::<Vec<String>>()
             .join(", ");
         write!(f, "{to_display}")

--- a/src/redacters/ms_presidio.rs
+++ b/src/redacters/ms_presidio.rs
@@ -127,11 +127,11 @@ impl<'a> MsPresidioRedacter<'a> {
 
         match input.content {
             RedacterDataItemContent::Image { mime_type, data } => {
-                self.reporter.report(format!(
+                self.reporter.report_debug(format!(
                     "Redacting an image file: {} ({:?})",
                     input.file_ref.relative_path.value(),
                     input.file_ref.media_type
-                ))?;
+                ));
                 let file_part = reqwest::multipart::Part::bytes(data.to_vec())
                     .file_name(input.file_ref.relative_path.filename())
                     .mime_str(mime_type.as_ref())

--- a/src/redacters/stream_redacter.rs
+++ b/src/redacters/stream_redacter.rs
@@ -1,3 +1,4 @@
+use crate::args::RedacterType;
 use crate::errors::AppError;
 use crate::file_converters::ocr::Ocr;
 use crate::file_converters::pdf::{PdfInfo, PdfPageInfo, PdfToImage};
@@ -10,18 +11,58 @@ use crate::redacters::{
 use crate::AppResult;
 use futures::{Stream, TryStreamExt};
 use image::ImageFormat;
-use indicatif::ProgressBar;
+use rvstruct::ValueStruct;
 use std::collections::HashSet;
 
+/// The conversion the content went through before it was redacted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedactionConversion {
+    /// The PDF was rendered to `pages` images, optionally read back with OCR.
+    PdfToImages { pages: usize, ocr: bool },
+    /// The image was read with the OCR engine.
+    Ocr,
+}
+
+/// Why the redaction pipeline did not redact the content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedactionBlocked {
+    /// The file is a PDF and no PDF renderer is available in this build.
+    PdfRendererUnavailable,
+    /// Redaction needs the OCR engine and it is not available in this build.
+    OcrUnavailable,
+    /// The OCR engine cannot read the image format of the file.
+    OcrImageFormatNotSupported,
+}
+
+/// What the pipeline actually did to a file, so the caller can report it once the
+/// transfer has finished rather than the pipeline announcing steps as it goes.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RedactionSummary {
+    /// The redacters that redacted the content, in the order they ran.
+    pub applied: Vec<RedacterType>,
+    /// The conversion applied before redaction, if any.
+    pub conversion: Option<RedactionConversion>,
+    /// Why nothing was redacted, when `applied` is empty.
+    pub blocked: Option<RedactionBlocked>,
+}
+
 pub struct RedactStreamResult {
+    /// How many redaction steps ran. This still counts a step that turned out to be a
+    /// no-op (see `summary`), because it decides whether the file is uploaded.
     pub number_of_redactions: usize,
+    pub summary: RedactionSummary,
     pub stream: Box<dyn Stream<Item = AppResult<bytes::Bytes>> + Send + Sync + Unpin + 'static>,
+}
+
+/// The result of running one OCR conversion step.
+enum OcrStepResult {
+    Redacted,
+    ImageFormatNotSupported,
 }
 
 pub struct StreamRedacter<'a> {
     redacter_base_options: &'a RedacterBaseOptions,
     file_converters: &'a FileConverters<'a>,
-    bar: &'a ProgressBar,
 }
 
 pub struct StreamRedactPlan<'a> {
@@ -35,12 +76,10 @@ impl<'a> StreamRedacter<'a> {
     pub fn new(
         redacter_base_options: &'a RedacterBaseOptions,
         file_converters: &'a FileConverters<'a>,
-        bar: &'a ProgressBar,
     ) -> Self {
         Self {
             redacter_base_options,
             file_converters,
-            bar,
         }
     }
 
@@ -155,83 +194,83 @@ impl<'a> StreamRedacter<'a> {
             .stream_to_redact_item(self.redacter_base_options, input, file_ref, &redact_plan)
             .await?;
         let mut number_of_redactions = 0;
+        let mut summary = RedactionSummary::default();
 
-        for (index, redacter) in redact_plan.supported_redacters.iter().enumerate() {
-            let width = " ".repeat(index);
+        for redacter in redact_plan.supported_redacters.iter() {
             if redact_plan.apply_pdf_image_converter {
                 match (
                     &self.file_converters.pdf_image_converter,
                     &self.file_converters.ocr,
                 ) {
                     (Some(ref pdf_to_image), _) if !redact_plan.apply_ocr => {
-                        redacted = self
+                        let (item, conversion) = self
                             .redact_pdf_with_images_converter(
                                 file_ref,
                                 redacted,
                                 *redacter,
-                                &width,
                                 pdf_to_image.as_ref(),
                                 None,
                             )
                             .await?;
+                        redacted = item;
                         number_of_redactions += 1;
+                        summary.applied.push(redacter.redacter_type());
+                        summary.conversion = conversion.or(summary.conversion);
                     }
                     (Some(ref pdf_to_image), Some(ref ocr)) => {
-                        redacted = self
+                        let (item, conversion) = self
                             .redact_pdf_with_images_converter(
                                 file_ref,
                                 redacted,
                                 *redacter,
-                                &width,
                                 pdf_to_image.as_ref(),
                                 Some(ocr.as_ref()),
                             )
                             .await?;
+                        redacted = item;
                         number_of_redactions += 1;
+                        summary.applied.push(redacter.redacter_type());
+                        summary.conversion = conversion.or(summary.conversion);
                     }
-                    (None, Some(_)) => {
-                        self.bar.println(format!(
-                            "{width}↲ Skipping redaction because PDF to image converter is not available",
-                        ));
+                    (None, Some(_)) | (None, None) => {
+                        summary.blocked = Some(RedactionBlocked::PdfRendererUnavailable);
                     }
                     (Some(_), None) => {
-                        self.bar.println(format!(
-                            "{width}↲ Skipping redaction because OCR is not available",
-                        ));
-                    }
-                    (None, None) => {
-                        self.bar.println(format!(
-                            "{width}↲ Skipping redaction because PDF/OCR are not available",
-                        ));
+                        summary.blocked = Some(RedactionBlocked::OcrUnavailable);
                     }
                 }
             } else if redact_plan.apply_ocr {
                 match self.file_converters.ocr {
                     Some(ref ocr) => {
-                        redacted = self
-                            .redact_with_ocr_converter(
-                                file_ref,
-                                redacted,
-                                *redacter,
-                                &width,
-                                ocr.as_ref(),
-                            )
+                        let (item, step) = self
+                            .redact_with_ocr_converter(file_ref, redacted, *redacter, ocr.as_ref())
                             .await?;
+                        redacted = item;
                         number_of_redactions += 1;
+                        match step {
+                            OcrStepResult::Redacted => {
+                                summary.applied.push(redacter.redacter_type());
+                                summary.conversion = Some(RedactionConversion::Ocr);
+                            }
+                            OcrStepResult::ImageFormatNotSupported => {
+                                summary.blocked =
+                                    Some(RedactionBlocked::OcrImageFormatNotSupported);
+                            }
+                        }
                     }
                     None => {
-                        self.bar.println(format!(
-                            "{width}↲ Skipping redaction because OCR is not available",
-                        ));
+                        summary.blocked = Some(RedactionBlocked::OcrUnavailable);
                     }
                 }
             } else {
-                self.bar.println(format!(
-                    "{width}↳ Redacting using {} redacter",
-                    redacter.redacter_type()
-                ));
+                tracing::debug!(
+                    redacter = %redacter.redacter_type(),
+                    file = %file_ref.relative_path.value(),
+                    "redacting"
+                );
                 redacted = redacter.redact(redacted).await?;
                 number_of_redactions += 1;
+                summary.applied.push(redacter.redacter_type());
             }
         }
 
@@ -260,6 +299,7 @@ impl<'a> StreamRedacter<'a> {
 
         Ok(RedactStreamResult {
             number_of_redactions,
+            summary,
             stream: output_stream,
         })
     }
@@ -410,21 +450,19 @@ impl<'a> StreamRedacter<'a> {
         file_ref: &FileSystemRef,
         redacted: RedacterDataItem,
         redacter: &impl Redacter,
-        width: &String,
         converter: &dyn PdfToImage,
         ocr: Option<&dyn Ocr>,
-    ) -> Result<RedacterDataItem, AppError> {
+    ) -> Result<(RedacterDataItem, Option<RedactionConversion>), AppError> {
         match redacted.content {
             RedacterDataItemContent::Pdf { data } => {
-                self.bar.println(format!(
-                    "{width}↳ Redacting using {} redacter and converting the PDF to images",
-                    redacter.redacter_type()
-                ));
+                tracing::debug!(
+                    redacter = %redacter.redacter_type(),
+                    file = %file_ref.relative_path.value(),
+                    "redacting the PDF as images"
+                );
                 let pdf_info = converter.convert_to_images(data)?;
-                self.bar.println(format!(
-                    "{width} ↳ Converting {pdf_info_pages} images",
-                    pdf_info_pages = pdf_info.pages.len()
-                ));
+                let pages = pdf_info.pages.len();
+                tracing::debug!(pages, "converting the PDF pages to images");
                 let mut redacted_pages = Vec::with_capacity(pdf_info.pages.len());
                 for page in pdf_info.pages {
                     let mut png_image_bytes = std::io::Cursor::new(Vec::new());
@@ -442,10 +480,10 @@ impl<'a> StreamRedacter<'a> {
                             file_ref,
                             image_to_redact,
                             redacter,
-                            &format!("  {width}"),
                             ocr_engine,
                         )
                         .await?
+                        .0
                     } else {
                         redacter.redact(image_to_redact).await?
                     };
@@ -463,14 +501,20 @@ impl<'a> StreamRedacter<'a> {
                     pages: redacted_pages,
                 };
                 let redact_pdf_as_images = converter.images_to_pdf(redacted_pdf_info)?;
-                Ok(RedacterDataItem {
-                    content: RedacterDataItemContent::Pdf {
-                        data: redact_pdf_as_images,
+                Ok((
+                    RedacterDataItem {
+                        content: RedacterDataItemContent::Pdf {
+                            data: redact_pdf_as_images,
+                        },
+                        file_ref: file_ref.clone(),
                     },
-                    file_ref: file_ref.clone(),
-                })
+                    Some(RedactionConversion::PdfToImages {
+                        pages,
+                        ocr: ocr.is_some(),
+                    }),
+                ))
             }
-            _ => Ok(redacted),
+            _ => Ok((redacted, None)),
         }
     }
 
@@ -479,17 +523,17 @@ impl<'a> StreamRedacter<'a> {
         file_ref: &FileSystemRef,
         redacted: RedacterDataItem,
         redacter: &impl Redacter,
-        width: &String,
         ocr: &dyn Ocr,
-    ) -> Result<RedacterDataItem, AppError> {
+    ) -> Result<(RedacterDataItem, OcrStepResult), AppError> {
         match &redacted.content {
             RedacterDataItemContent::Image { data, mime_type } => {
                 match ImageFormat::from_mime_type(mime_type) {
                     Some(image_format) => {
-                        self.bar.println(format!(
-                            "{width}↳ Redacting using {} redacter and converting the image to text using OCR engine",
-                            redacter.redacter_type()
-                        ));
+                        tracing::debug!(
+                            redacter = %redacter.redacter_type(),
+                            file = %file_ref.relative_path.value(),
+                            "redacting the image with the OCR engine"
+                        );
                         let image = image::load_from_memory_with_format(data, image_format)?;
                         let text_coords = ocr.image_to_text(image.clone())?;
                         let text = text_coords
@@ -526,13 +570,16 @@ impl<'a> StreamRedacter<'a> {
                                 }
                                 let mut output = std::io::Cursor::new(Vec::new());
                                 redacted_image.write_to(&mut output, image_format)?;
-                                Ok(RedacterDataItem {
-                                    file_ref: file_ref.clone(),
-                                    content: RedacterDataItemContent::Image {
-                                        mime_type: mime_type.clone(),
-                                        data: output.into_inner().into(),
+                                Ok((
+                                    RedacterDataItem {
+                                        file_ref: file_ref.clone(),
+                                        content: RedacterDataItemContent::Image {
+                                            mime_type: mime_type.clone(),
+                                            data: output.into_inner().into(),
+                                        },
                                     },
-                                })
+                                    OcrStepResult::Redacted,
+                                ))
                             }
                             _ => Err(AppError::SystemError {
                                 message: "Redacted text is not returned as text".to_string(),
@@ -540,14 +587,16 @@ impl<'a> StreamRedacter<'a> {
                         }
                     }
                     None => {
-                        self.bar.println(format!(
-                            "{width}↲ Skipping redaction through OCR because image format is not supported",
-                        ));
-                        Ok(redacted)
+                        tracing::debug!(
+                            media_type = %mime_type,
+                            file = %file_ref.relative_path.value(),
+                            "skipping OCR because the image format is not supported"
+                        );
+                        Ok((redacted, OcrStepResult::ImageFormatNotSupported))
                     }
                 }
             }
-            _ => Ok(redacted),
+            _ => Ok((redacted, OcrStepResult::Redacted)),
         }
     }
 }

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -8,6 +8,16 @@ pub struct AppReporter<'a> {
 }
 
 impl<'a> AppReporter<'a> {
+    /// Reports internal progress detail that is not part of the command's output: it
+    /// goes to `tracing` (`RUST_LOG=debug`) instead of the terminal, so it never lands
+    /// in the middle of the table a command is printing.
+    pub fn report_debug<S>(&'a self, message: S)
+    where
+        S: AsRef<str>,
+    {
+        tracing::debug!("{}", message.as_ref());
+    }
+
     pub fn report<S>(&'a self, message: S) -> AppResult<()>
     where
         S: AsRef<str>,


### PR DESCRIPTION
The cp command now prints one glyph-led row per file when the file finishes - redacted, copied as is, skipped or error - with a dimmed legend above the table and a single count summary at the end, instead of a processing line plus indented step lines. The redaction pipeline returns the outcome it produced rather than printing its steps, and the listing and extraction chatter now goes to tracing, visible with RUST_LOG=debug.