### PR TITLE
Add offline local-gliner redacter (GLiNER-PII on rten)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities"]
 description = "Copy & Redact cli tool to securely copy and redact files removing Personal Identifiable Information (PII) across various filesystems."
 
 [features]
-default = ["pdf-render", "clipboard", "ocr", "local-ner"]
+default = ["pdf-render", "clipboard", "ocr", "local-ner", "local-gliner"]
 ci-gcp = [] # For testing on CI/GCP
 ci-aws = [] # For testing on CI/AWS
 ci-ms-presidio = [] # For testing on CI/MS Presidiom
@@ -24,6 +24,7 @@ ci-open-ai = [] # For testing on CI/OpenAIP
 ci-clipboard = [] # For testing on CI/Clipboard
 ci-ocr = [] # For testing on CI/OCR
 ci-local-ner = [] # For testing on CI with the downloaded local NER model
+ci-local-gliner = [] # For testing on CI with the downloaded local GLiNER model
 ci-gcp-vertex-ai = [] # For testing on CI/GCP with Vertex AI
 ci = [
     "ci-gcp",
@@ -38,6 +39,7 @@ pdf-render = ["pdfium-render"]
 clipboard = ["arboard"]
 ocr = ["ocrs", "rten", "rten-imageproc"]
 local-ner = ["tokenizers", "rten", "rten-tensor"]
+local-gliner = ["tokenizers", "rten", "rten-tensor"]
 
 [dependencies]
 rsb_derive = "0.5"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ find more. See [Local or cloud](#local-or-cloud-quality-versus-performance) for 
         * text, html, csv, json files
         * images through text extraction using OCR
         * PDF files (rendering as images from OCR)
+    * Local GLiNER redacter: offline, zero-shot span detection against free-text labels you
+      choose, understanding context that `local-ner` cannot. No cloud account needed:
+        * text, html, csv, json files
+        * images through text extraction using OCR
+        * PDF files (rendering as images from OCR)
     * [AWS Bedrock](https://aws.amazon.com/bedrock/) based redaction using Amazon Nova and other models available on Bedrock
         * text, html, csv, json files
         * images, redacted by blacking out the coordinates the model reports
@@ -86,8 +91,9 @@ cargo install redacter
 
 - If you are planning to use PDF redaction, please follow additional steps in
 the [PDF redaction](#pdf-redaction)
-- OCR (for the DLP providers that can't read images) and the `local-ner` redacter need model files that
-  are downloaded on request or installed by hand, see [Models and downloads](#models-and-downloads).
+- OCR (for the DLP providers that can't read images) and the `local-ner` and `local-gliner` redacters
+  need model files that are downloaded on request or installed by hand, see
+  [Models and downloads](#models-and-downloads).
 
 ## Command line options
 
@@ -105,7 +111,7 @@ Arguments:
 
 Options:
       --download-models <DOWNLOAD_MODELS>
-          Whether missing model files (OCR, local-ner) may be downloaded: 'ask' prompts on the terminal and behaves as 'no' when stdin or stderr is not a terminal, 'yes' downloads without asking, 'no' never downloads. Default is 'ask'
+          Whether missing model files (OCR, local-ner, local-gliner) may be downloaded: 'ask' prompts on the terminal and behaves as 'no' when stdin or stderr is not a terminal, 'yes' downloads without asking, 'no' never downloads. Default is 'ask'
           
           [default: ask]
           [possible values: ask, yes, no]
@@ -125,7 +131,7 @@ Options:
   -d, --redact <REDACT>
           List of redacters to use
           
-          [possible values: gcp-dlp, aws-comprehend, ms-presidio, gemini-llm, open-ai-llm, gcp-vertex-ai, aws-bedrock, aws-bedrock-guardrails, local-rules, local-ner]
+          [possible values: gcp-dlp, aws-comprehend, ms-presidio, gemini-llm, open-ai-llm, gcp-vertex-ai, aws-bedrock, aws-bedrock-guardrails, local-rules, local-ner, local-gliner]
 
       --allow-unsupported-copies
           Allow unsupported types to be copied without redaction
@@ -229,6 +235,14 @@ Options:
 
       --local-ner-min-score <LOCAL_NER_MIN_SCORE>
           Minimum model confidence for a word to be redacted by local-ner, between 0 and 1. Lower values redact more. Default is 0.5
+          
+          [default: 0.5]
+
+      --local-gliner-labels <LOCAL_GLINER_LABELS>
+          Entity labels the local-gliner redacter looks for, comma separated, free text understood by the model (for example "person,email,medical condition"). Default is a PII list: person, address, email, phone number, date of birth, passport number, national id number, credit card number, iban, ip address, username, medical condition, postal code, license plate number
+
+      --local-gliner-min-score <LOCAL_GLINER_MIN_SCORE>
+          Minimum model confidence for a span to be redacted by local-gliner, between 0 and 1. Lower values redact more. Default is 0.5
           
           [default: 0.5]
 
@@ -530,47 +544,129 @@ the ONNX export by Xenova of [Davlan/distilbert-base-multilingual-cased-ner-hrl]
 by David Adelani, released under the [Academic Free License 3.0](https://opensource.org/license/afl-3-0-php).
 The model is not bundled with the tool.
 
+### Local GLiNER redacter
+
+The `local-gliner` redacter runs a zero-shot span model entirely on your machine: instead of a fixed
+label set, you give it the entity labels to look for as free text, and it scores every span of the
+document against each one. It replaces each match with `[REDACTED]`, like the other local redacters.
+Unlike `local-ner`, it reads context: it finds a lower-case name with no capitalisation to key off, a
+medical condition described in a sentence, a date of birth with no `date of birth` keyword next to it,
+and handles and usernames written as free text, none of which `local-rules` or `local-ner` can find on
+their own. It uses [`urchade/gliner_multi_pii-v1`](https://huggingface.co/urchade/gliner_multi_pii-v1)
+(the [onnx-community](https://huggingface.co/onnx-community/gliner_multi_pii-v1) ONNX export),
+trained on six languages: English, French, German, Spanish, Italian and Portuguese. Nothing leaves your
+computer; the only network access is the one-time, opt-in download of the model files described in
+[Models and downloads](#models-and-downloads).
+
+Like `local-rules` and `local-ner`, an image or a PDF first goes through the OCR engine: every recognised
+word is passed to the model as if it were reading the page as text, and every word the chain redacts is
+blacked out on a rasterised copy of the page.
+
+```sh
+# The default PII label list
+redacter cp -d local-gliner tmp/source/ tmp/redacted/
+
+# Your own labels, and redact more aggressively
+redacter cp -d local-gliner --local-gliner-labels "person,email,medical condition" --local-gliner-min-score 0.3 tmp/source/ tmp/redacted/
+
+# Pattern-shaped data by rules, everything else by the context-aware model, all offline
+redacter cp -d local-rules -d local-gliner tmp/source/ tmp/redacted/
+```
+
+`--local-gliner-labels` is a comma-separated list of free-text labels, understood by the model rather
+than looked up in a fixed taxonomy; the default is a PII-only list: person, address, email, phone
+number, date of birth, passport number, national id number, credit card number, iban, ip address,
+username, medical condition, postal code, license plate number. `organization` is deliberately not in
+the default list: measured against this model, it tags team and desk names such as "Marketing team" and
+"The Support Desk" as organisations, which is over-redaction for a label most callers do not want on by
+default; add it with `--local-gliner-labels` when you do. `--local-gliner-min-score` is the model
+confidence a span needs to be redacted, between 0 and 1 (default 0.5); lower values redact more. Scores
+are well separated in practice, so lowering the threshold rarely changes the result.
+
+Use a release binary (or `cargo run --release`) for `local-gliner`: like `local-ner`, a debug build is
+far slower than release. In release, on an Intel i7-10700K (16 threads), loading the model takes about
+0.6 s and it holds about 1.5 GB of peak memory while redacting a small text corpus; the download in
+[Models and downloads](#models-and-downloads) is about 1.17 GB, almost all of it the fp32 model weights
+(the int8 export cannot be used: its span head has an operator this tool's ONNX runtime does not
+support). On the benchmark corpus under `test-fixtures/bench-dlp/` this measured 784 ms per file and
+2.4 s over the whole 8-file corpus, both dominated by the model's forward pass; a document scores each
+label in batches of at most 25, so more labels cost more passes and, as with `organization` above, more
+false positives.
+
+A date that merely looks like a date of birth may still be redacted regardless of context, since the
+model has learned the shape as well as the wording -- on the benchmark corpus this catches the invoice
+date `14 March 1985` in `dates-en.txt`, which carries no birth-related wording at all. A single word with
+nothing around it can still be missed the way it can with `local-ner`, since the model also relies on
+context to score a span highly.
+It works natively on text, html, json and csv files, and handles images and PDFs the way the AWS
+Comprehend redacter does: through OCR and Pdfium, when those optional capabilities are installed.
+
+The model is Apache-2.0, [`urchade/gliner_multi_pii-v1`](https://huggingface.co/urchade/gliner_multi_pii-v1)
+by Urchade Zaratiana, trained on the Apache-2.0
+[`urchade/synthetic-pii-ner-mistral-v1`](https://huggingface.co/datasets/urchade/synthetic-pii-ner-mistral-v1)
+dataset; its backbone, `microsoft/mdeberta-v3-base`, is MIT licensed. The model is not bundled with the
+tool.
+
 ### Local or cloud: quality versus performance
 
-The two local redacters run entirely on your machine, so nothing leaves it, nothing is billed and nothing needs
+The three local redacters run entirely on your machine, so nothing leaves it, nothing is billed and nothing needs
 credentials. The price is detection quality: curated rules only find what has a shape (emails, phones, cards,
-IBANs, keys, national ids with checksums), and a small named-entity model only finds persons, organisations and
-locations in the ten languages it was trained on. A cloud DLP service knows hundreds of info types, and an LLM
-understands context, so both find more, at the cost of latency, money, and sending the document out.
+IBANs, keys, national ids with checksums); a small named-entity model only finds persons, organisations and
+locations in the ten languages it was trained on; a zero-shot span model (`local-gliner`) reads context well
+enough to close most of that gap, at several times the latency and over a gigabyte of memory. A cloud DLP
+service knows hundreds of info types, and an LLM reasons over the whole document, so both can still find more
+in the hardest cases, at the cost of latency, money, and sending the document out.
 
 Pros of local redaction:
 
 - Privacy by construction: works air-gapped, no account, no per-request cost, no rate limits.
-- Speed: rules run in microseconds; the NER model needs about 100 ms per 512 tokens on a desktop CPU.
+- Speed: rules run in microseconds; the NER model needs about 100 ms per 512 tokens on a desktop CPU;
+  GLiNER is slower, under a second per file, but still local and free.
 - Determinism: the same input always gives the same output, which makes results easy to test and audit.
-- A useful pre-pass: `-d local-rules -d local-ner -d gcp-dlp` removes the obvious PII before anything is sent.
+- A useful pre-pass: `-d local-rules -d local-ner -d gcp-dlp` (or `-d local-gliner` in place of `local-ner`)
+  removes the obvious PII before anything is sent.
 
 Cons of local redaction:
 
-- Narrower coverage: no free-form addresses and no document-level reasoning; dates of birth, passport and
-  licence numbers only next to a context keyword.
-- Model quality: a 66M-parameter model misses names it has never seen, needs context to tag a single word,
-  and reports organisations for product names.
+- Narrower coverage without `local-gliner`: `local-rules` alone has no free-form addresses or document-level
+  reasoning, and only redacts dates of birth, passport and licence numbers next to a context keyword.
+- Model quality: the 66M-parameter NER model misses names it has never seen, needs context to tag a single
+  word, and reports organisations for product names; GLiNER can mistake a plain date for a date of birth by
+  shape alone, and more labels bring more of that kind of false positive.
+- Resource cost: `local-gliner`'s model is a ~1.17 GB download and needs about 1.5 GB of memory while running,
+  against `local-ner`'s 132 MB and 232 MB.
 - Locale-bound rules: national formats differ; expect to enable, disable or add rules for your documents.
 
-Measured on the small corpus under `test-fixtures/bench-dlp/` (four fixture documents plus a multilingual sample,
-about 4 KB of text; local rows at commit `540fbc5`, cloud rows from the run at commit `3c3491e`, Intel i7-10700K,
-one warm-up then the median of three runs; the cloud numbers include network time from Europe):
+Measured on the corpus under `test-fixtures/bench-dlp/` (eight fixture documents including a contextual note
+written so its PII needs context rather than shape to find, about 3.7 KB of text; local rows measured at
+commit `f1f7ea2`, Intel i7-10700K, one warm-up then the median of three runs). The cloud rows are kept from an
+earlier run on a 7-file corpus (commit `3c3491e`, before the contextual file was added, 41 PII / 7 entities /
+25 keep) and were not re-run against the current corpus, so they are not directly comparable to the PII/kept
+counts below:
 
 | Redacter | Whole corpus | Per file (median) | PII removed | Cities and organisations removed | Non-PII kept |
 |---|---|---|---|---|---|
-| `local-rules` | 38 ms | 35 ms | 28 / 41 | 0 / 7 | 25 / 25 |
-| `local-ner` | 370 ms | 144 ms | 15 / 41 | 7 / 7 | 23 / 25 |
-| `local-rules` + `local-ner` | 431 ms | 174 ms | 41 / 41 | 7 / 7 | 23 / 25 |
-| `gcp-dlp` | 710 ms | 266 ms | 40 / 41 | 4 / 7 | 25 / 25 |
-| `gcp-vertex-ai` (Gemini) | 68.9 s | 6.0 s | 41 / 41 | 1 / 7 | 24 / 25 |
+| `local-rules` | 51 ms | 49 ms | 28 / 48 | 0 / 8 | 31 / 31 |
+| `local-ner` | 409 ms | 146 ms | 17 / 48 | 8 / 8 | 27 / 31 |
+| `local-rules` + `local-ner` | 468 ms | 192 ms | 43 / 48 | 8 / 8 | 27 / 31 |
+| `local-gliner` | 2.4 s | 784 ms | 45 / 48 | 1 / 8 | 28 / 31 |
+| `local-rules` + `local-gliner` | 2.5 s | 823 ms | 48 / 48 | 1 / 8 | 27 / 31 |
+| `gcp-dlp` (7-file corpus) | 710 ms | 266 ms | 40 / 41 | 4 / 7 | 25 / 25 |
+| `gcp-vertex-ai` (Gemini, 7-file corpus) | 68.9 s | 6.0 s | 41 / 41 | 1 / 7 | 24 / 25 |
 
-The 13 PII strings `local-rules` leaves behind are the person names and the free-form street addresses,
-which have no shape to match; the chain with `local-ner` removes all 41, since the rules now cover the
-three dates of birth, the UK postcode and the passport number. GCP DLP misses only the postcode and
-Gemini misses nothing. The two non-PII strings the NER model removes are "Apple" in "Apple pie" and the
-sign-off "The Support Desk", both tagged as organisations, which is the over-redaction to expect from
-entity-based detection. Run `cargo test --release --test bench_dlp -- --ignored --nocapture` (see
+`local-rules` still leaves behind the person names and free-form street addresses that have no shape to
+match; `local-rules+local-ner` closes most of that gap but, with no notion of context, still misses the
+contextual file's lower-case name, medical condition, keyword-less date of birth and two handles (43/48).
+`local-gliner` on its own reaches 45/48 with its default 14-label PII list, and chained after `local-rules`
+reaches 48/48 -- every PII string in the corpus, including all of the contextual file's. Since `organization`
+is off by default, `local-gliner` redacts only the one `entities` string embedded in a free-form address
+(1/8) rather than `local-ner`'s 8/8; entity coverage is available via `--local-gliner-labels` but costs the
+false positives that come with it. The keep losses beyond `local-rules`' clean 31/31 are the known
+over-redaction cases: `local-ner` and the `local-ner` chain tag "Apple" and "The Support Desk" as
+organisations; `local-gliner` and its chain occasionally tag a sentence mentioning email preferences as a
+username or address, and mistake the invoice date `14 March 1985` in `dates-en.txt` for a date of birth by
+shape alone, the same false positive noted in the [Local GLiNER redacter](#local-gliner-redacter) section.
+Run `cargo test --release --test bench_dlp -- --ignored --nocapture` (see
 `test-fixtures/bench-dlp/README.md`) to reproduce the table on your own machine and documents.
 
 In short: use the local redacters when the data must not leave the machine or when you need a fast, cheap
@@ -605,12 +701,14 @@ If library is detected correctly it will be reported in the tool output as.
 
 ## Models and downloads
 
-The OCR engine and the `local-ner` redacter need model files that are not bundled with the tool:
+The OCR engine and the `local-ner` and `local-gliner` redacters need model files that are not bundled
+with the tool:
 
 | Model | Files | Size | Source | Licence |
 |---|---|---|---|---|
 | `ocrs` (OCR) | `text-detection.rten`, `text-recognition.rten` | 11.7 MiB | https://ocrs-models.s3-accelerate.amazonaws.com/ | MIT OR Apache-2.0 (ocrs); weights trained on open, liberally licensed datasets |
 | `distilbert-base-multilingual-cased-ner-hrl` (`local-ner`) | `model_uint8.onnx`, `tokenizer.json`, `config.json` | 131.6 MiB | https://huggingface.co/Xenova/distilbert-base-multilingual-cased-ner-hrl (revision `c2a4dbf`) | AFL-3.0 |
+| `gliner_multi_pii-v1` (`local-gliner`) | `model.onnx`, `tokenizer.json`, `gliner_config.json` | 1.1 GiB | https://huggingface.co/onnx-community/gliner_multi_pii-v1 (revision `2e0397a7`) | Apache-2.0 (model and training data); backbone `microsoft/mdeberta-v3-base` MIT |
 
 Nothing is downloaded without your consent. `--download-models` controls it:
 
@@ -737,8 +835,8 @@ redacter ls gs://my-little-bucket/my-big-files/
 ## Security considerations
 
 - Your file contents are sent to the DLP API for redaction. Make sure you trust the DLP API provider.
-- The local redacters (`local-rules`, `local-ner`) send nothing anywhere. Their model files are
-  fetched only on request, over HTTPS, and checked against SHA-256 digests pinned in the tool.
+- The local redacters (`local-rules`, `local-ner`, `local-gliner`) send nothing anywhere. Their model
+  files are fetched only on request, over HTTPS, and checked against SHA-256 digests pinned in the tool.
 - The accuracy of redaction depends on the DLP model, so don't rely on it as the only security measure.
 - The tool was mostly designed to redact files internally. Not recommended to use it in public environments without
   apropriate security measures and manual review.

--- a/README.md
+++ b/README.md
@@ -589,19 +589,17 @@ far slower than release. In release, on an Intel i7-10700K (16 threads), loading
 [Models and downloads](#models-and-downloads) is about 1.17 GB, almost all of it the fp32 model weights
 (the int8 export cannot be used: its span head has an operator this tool's ONNX runtime does not
 support). On the benchmark corpus under `test-fixtures/bench-dlp/` this measured 834 ms per file and
-2.8 s over the whole 8-file corpus, both dominated by the model's forward pass; the per-file figure
-includes process start and the ~0.6 s model load, since the benchmark harness invokes the binary once
-per file rather than scoring in one long-lived process, so it should not be read as in-process inference
-time. A document scores each label in batches of at most 25, so more labels cost more passes and, as
-with `organization` above, more false positives.
+2.8 s over the whole 8-file corpus. The per-file figure includes process start and the ~0.6 s model
+load, since the benchmark harness invokes the binary once per file rather than scoring in one
+long-lived process; the forward pass itself takes roughly 100-200 ms per 384-token window. A document
+scores each label in batches of at most 25, so more labels cost more passes and, as with
+`organization` above, more false positives.
 
 A date that merely looks like a date of birth may still be redacted regardless of context, since the
 model has learned the shape as well as the wording -- on the benchmark corpus this catches the invoice
 date `14 March 1985` in `dates-en.txt`, which carries no birth-related wording at all. A single word with
 nothing around it can still be missed the way it can with `local-ner`, since the model also relies on
 context to score a span highly.
-It works natively on text, html, json and csv files, and handles images and PDFs the way the AWS
-Comprehend redacter does: through OCR and Pdfium, when those optional capabilities are installed.
 
 The model is Apache-2.0, [`urchade/gliner_multi_pii-v1`](https://huggingface.co/urchade/gliner_multi_pii-v1)
 by Urchade Zaratiana, trained on the Apache-2.0
@@ -667,8 +665,8 @@ structured PII on its own. Since `organization` is off by default, `local-gliner
 `entities` string embedded in a free-form address (1/8) rather than `local-ner`'s 8/8; entity coverage is
 available via `--local-gliner-labels` but costs the false positives that come with it. The keep losses
 beyond `local-rules`' clean 31/31 are the known over-redaction cases: `local-ner` and the `local-ner`
-chain tag "Apple" and "The Support Desk" as organisations; `local-gliner` and its chain occasionally tag a
-sentence mentioning email preferences as a username or address, and mistake the invoice date
+chain tag "Apple" and "The Support Desk" as organisations; `local-gliner` and its chain tag the word "email"
+in a sentence about contact preferences as an email address, and mistake the invoice date
 `14 March 1985` in `dates-en.txt` for a date of birth by shape alone, the same false positive noted in the
 [Local GLiNER redacter](#local-gliner-redacter) section.
 Run `cargo test --release --test bench_dlp -- --ignored --nocapture` (see

--- a/README.md
+++ b/README.md
@@ -588,10 +588,12 @@ far slower than release. In release, on an Intel i7-10700K (16 threads), loading
 0.6 s and it holds about 1.5 GB of peak memory while redacting a small text corpus; the download in
 [Models and downloads](#models-and-downloads) is about 1.17 GB, almost all of it the fp32 model weights
 (the int8 export cannot be used: its span head has an operator this tool's ONNX runtime does not
-support). On the benchmark corpus under `test-fixtures/bench-dlp/` this measured 784 ms per file and
-2.4 s over the whole 8-file corpus, both dominated by the model's forward pass; a document scores each
-label in batches of at most 25, so more labels cost more passes and, as with `organization` above, more
-false positives.
+support). On the benchmark corpus under `test-fixtures/bench-dlp/` this measured 834 ms per file and
+2.8 s over the whole 8-file corpus, both dominated by the model's forward pass; the per-file figure
+includes process start and the ~0.6 s model load, since the benchmark harness invokes the binary once
+per file rather than scoring in one long-lived process, so it should not be read as in-process inference
+time. A document scores each label in batches of at most 25, so more labels cost more passes and, as
+with `organization` above, more false positives.
 
 A date that merely looks like a date of birth may still be redacted regardless of context, since the
 model has learned the shape as well as the wording -- on the benchmark corpus this catches the invoice
@@ -639,33 +641,36 @@ Cons of local redaction:
 
 Measured on the corpus under `test-fixtures/bench-dlp/` (eight fixture documents including a contextual note
 written so its PII needs context rather than shape to find, about 3.7 KB of text; local rows measured at
-commit `f1f7ea2`, Intel i7-10700K, one warm-up then the median of three runs). The cloud rows are kept from an
-earlier run on a 7-file corpus (commit `3c3491e`, before the contextual file was added, 41 PII / 7 entities /
-25 keep) and were not re-run against the current corpus, so they are not directly comparable to the PII/kept
-counts below:
+commit `e9b325d`, Intel i7-10700K, one warm-up then the median of three runs; per-file figures include
+process start and model load, since the harness invokes the binary once per file). The cloud rows are kept
+from an earlier run on a 7-file corpus (commit `3c3491e`, before the contextual file was added, 41 PII / 7
+entities / 25 keep) and were not re-run against the current corpus, so they are not directly comparable to
+the PII/kept counts below:
 
 | Redacter | Whole corpus | Per file (median) | PII removed | Cities and organisations removed | Non-PII kept |
 |---|---|---|---|---|---|
-| `local-rules` | 51 ms | 49 ms | 28 / 48 | 0 / 8 | 31 / 31 |
-| `local-ner` | 409 ms | 146 ms | 17 / 48 | 8 / 8 | 27 / 31 |
-| `local-rules` + `local-ner` | 468 ms | 192 ms | 43 / 48 | 8 / 8 | 27 / 31 |
-| `local-gliner` | 2.4 s | 784 ms | 45 / 48 | 1 / 8 | 28 / 31 |
-| `local-rules` + `local-gliner` | 2.5 s | 823 ms | 48 / 48 | 1 / 8 | 27 / 31 |
+| `local-rules` | 52 ms | 49 ms | 28 / 48 | 0 / 8 | 31 / 31 |
+| `local-ner` | 441 ms | 152 ms | 17 / 48 | 8 / 8 | 27 / 31 |
+| `local-rules` + `local-ner` | 466 ms | 205 ms | 43 / 48 | 8 / 8 | 27 / 31 |
+| `local-gliner` | 2.8 s | 834 ms | 48 / 48 | 1 / 8 | 28 / 31 |
+| `local-rules` + `local-gliner` | 2.7 s | 878 ms | 48 / 48 | 1 / 8 | 27 / 31 |
 | `gcp-dlp` (7-file corpus) | 710 ms | 266 ms | 40 / 41 | 4 / 7 | 25 / 25 |
 | `gcp-vertex-ai` (Gemini, 7-file corpus) | 68.9 s | 6.0 s | 41 / 41 | 1 / 7 | 24 / 25 |
 
 `local-rules` still leaves behind the person names and free-form street addresses that have no shape to
 match; `local-rules+local-ner` closes most of that gap but, with no notion of context, still misses the
 contextual file's lower-case name, medical condition, keyword-less date of birth and two handles (43/48).
-`local-gliner` on its own reaches 45/48 with its default 14-label PII list, and chained after `local-rules`
-reaches 48/48 -- every PII string in the corpus, including all of the contextual file's. Since `organization`
-is off by default, `local-gliner` redacts only the one `entities` string embedded in a free-form address
-(1/8) rather than `local-ner`'s 8/8; entity coverage is available via `--local-gliner-labels` but costs the
-false positives that come with it. The keep losses beyond `local-rules`' clean 31/31 are the known
-over-redaction cases: `local-ner` and the `local-ner` chain tag "Apple" and "The Support Desk" as
-organisations; `local-gliner` and its chain occasionally tag a sentence mentioning email preferences as a
-username or address, and mistake the invoice date `14 March 1985` in `dates-en.txt` for a date of birth by
-shape alone, the same false positive noted in the [Local GLiNER redacter](#local-gliner-redacter) section.
+`local-gliner` reaches 48/48 with its default 14-label PII list on its own -- every PII string in the
+corpus, including all of the contextual file's and the digit-only phone numbers in `customers.csv` --
+and chained after `local-rules` also stays at 48/48, since `local-rules` already covers the same
+structured PII on its own. Since `organization` is off by default, `local-gliner` redacts only the one
+`entities` string embedded in a free-form address (1/8) rather than `local-ner`'s 8/8; entity coverage is
+available via `--local-gliner-labels` but costs the false positives that come with it. The keep losses
+beyond `local-rules`' clean 31/31 are the known over-redaction cases: `local-ner` and the `local-ner`
+chain tag "Apple" and "The Support Desk" as organisations; `local-gliner` and its chain occasionally tag a
+sentence mentioning email preferences as a username or address, and mistake the invoice date
+`14 March 1985` in `dates-en.txt` for a date of birth by shape alone, the same false positive noted in the
+[Local GLiNER redacter](#local-gliner-redacter) section.
 Run `cargo test --release --test bench_dlp -- --ignored --nocapture` (see
 `test-fixtures/bench-dlp/README.md`) to reproduce the table on your own machine and documents.
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -886,5 +886,12 @@ mod tests {
             let err = local_gliner_options(&["--local-gliner-labels", "person,  "]).unwrap_err();
             assert!(matches!(err, AppError::RedacterConfigError { .. }), "{err}");
         }
+
+        #[test]
+        fn a_trailing_comma_is_a_config_error() {
+            let err =
+                local_gliner_options(&["--local-gliner-labels", "person,email,"]).unwrap_err();
+            assert!(matches!(err, AppError::RedacterConfigError { .. }), "{err}");
+        }
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,8 @@
 use crate::common_types::{DlpRequestLimit, GcpProjectId, GcpRegion};
 use crate::errors::AppError;
 use crate::model_store::DownloadModels;
+#[cfg(feature = "local-gliner")]
+use crate::redacters::LocalGlinerRedacterOptions;
 use crate::redacters::{
     AwsBedrockGuardrailId, AwsBedrockGuardrailVersion, AwsBedrockModelName, GcpDlpRedacterOptions,
     GcpVertexAiModelName, GeminiLlmModelName, LlmImageMode, LocalRulesRedacterOptions,
@@ -28,7 +30,7 @@ pub struct CliArgs {
         global = true,
         value_enum,
         default_value = "ask",
-        help = "Whether missing model files (OCR, local-ner) may be downloaded: 'ask' prompts on the terminal and behaves as 'no' when stdin or stderr is not a terminal, 'yes' downloads without asking, 'no' never downloads. Default is 'ask'"
+        help = "Whether missing model files (OCR, local-ner, local-gliner) may be downloaded: 'ask' prompts on the terminal and behaves as 'no' when stdin or stderr is not a terminal, 'yes' downloads without asking, 'no' never downloads. Default is 'ask'"
     )]
     pub download_models: DownloadModels,
 
@@ -143,6 +145,7 @@ pub enum RedacterType {
     AwsBedrockGuardrails,
     LocalRules,
     LocalNer,
+    LocalGliner,
 }
 
 impl std::str::FromStr for RedacterType {
@@ -160,6 +163,7 @@ impl std::str::FromStr for RedacterType {
             "aws-bedrock-guardrails" => Ok(RedacterType::AwsBedrockGuardrails),
             "local-rules" => Ok(RedacterType::LocalRules),
             "local-ner" => Ok(RedacterType::LocalNer),
+            "local-gliner" => Ok(RedacterType::LocalGliner),
             _ => Err(format!("Unknown redacter type: {s}")),
         }
     }
@@ -178,6 +182,7 @@ impl Display for RedacterType {
             RedacterType::AwsBedrockGuardrails => write!(f, "aws-bedrock-guardrails"),
             RedacterType::LocalRules => write!(f, "local-rules"),
             RedacterType::LocalNer => write!(f, "local-ner"),
+            RedacterType::LocalGliner => write!(f, "local-gliner"),
         }
     }
 }
@@ -363,6 +368,22 @@ pub struct RedacterArgs {
         help = "Minimum model confidence for a word to be redacted by local-ner, between 0 and 1. Lower values redact more. Default is 0.5"
     )]
     pub local_ner_min_score: f32,
+
+    #[cfg(feature = "local-gliner")]
+    #[arg(
+        long,
+        value_delimiter = ',',
+        help = "Entity labels the local-gliner redacter looks for, comma separated, free text understood by the model (for example \"person,email,medical condition\"). Default is a PII list: person, address, email, phone number, date of birth, passport number, national id number, credit card number, iban, ip address, username, medical condition, postal code, license plate number"
+    )]
+    pub local_gliner_labels: Option<Vec<String>>,
+
+    #[cfg(feature = "local-gliner")]
+    #[arg(
+        long,
+        default_value_t = 0.5,
+        help = "Minimum model confidence for a span to be redacted by local-gliner, between 0 and 1. Lower values redact more. Default is 0.5"
+    )]
+    pub local_gliner_min_score: f32,
 }
 
 impl TryInto<RedacterOptions> for RedacterArgs {
@@ -521,6 +542,23 @@ impl TryInto<RedacterOptions> for RedacterArgs {
                     message: "local-ner is not available in this build (compiled without the local-ner feature)"
                         .to_string(),
                 }),
+                #[cfg(feature = "local-gliner")]
+                RedacterType::LocalGliner => {
+                    let labels = match &self.local_gliner_labels {
+                        Some(list) => list.clone(),
+                        None => crate::redacters::local_gliner::labels::default_labels(),
+                    };
+                    LocalGlinerRedacterOptions::validated(labels, self.local_gliner_min_score)
+                        .map(RedacterProviderOptions::LocalGliner)
+                        .map_err(|err| AppError::RedacterConfigError {
+                            message: err.to_string(),
+                        })
+                }
+                #[cfg(not(feature = "local-gliner"))]
+                RedacterType::LocalGliner => Err(AppError::RedacterConfigError {
+                    message: "local-gliner is not available in this build (compiled without the local-gliner feature)"
+                        .to_string(),
+                }),
             }?;
             provider_options.push(redacter_options);
         }
@@ -627,6 +665,7 @@ mod tests {
             RedacterType::AwsBedrockGuardrails,
             RedacterType::LocalRules,
             RedacterType::LocalNer,
+            RedacterType::LocalGliner,
         ] {
             let name = redacter_type.to_string();
             let parsed = <RedacterType as FromStr>::from_str(&name)
@@ -793,6 +832,59 @@ mod tests {
             let err = local_ner_options(&["--local-ner-min-score", "1.5"]).unwrap_err();
             assert!(matches!(err, AppError::RedacterConfigError { .. }), "{err}");
             assert!(err.to_string().contains("1.5"), "{err}");
+        }
+    }
+
+    #[cfg(feature = "local-gliner")]
+    mod local_gliner {
+        use super::*;
+        use crate::redacters::local_gliner::labels::default_labels;
+        use crate::redacters::LocalGlinerRedacterOptions;
+
+        fn local_gliner_options(args: &[&str]) -> Result<LocalGlinerRedacterOptions, AppError> {
+            let cli = TestCli::try_parse_from([&["redacter", "-d", "local-gliner"], args].concat())
+                .unwrap_or_else(|err| panic!("{err}"));
+            let options: RedacterOptions = cli.redacter.try_into()?;
+            match options.provider_options.into_iter().next() {
+                Some(RedacterProviderOptions::LocalGliner(options)) => Ok(options),
+                other => panic!("expected local gliner options, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn defaults_to_the_pii_label_list_at_half_score() {
+            let options = local_gliner_options(&[]).unwrap();
+            assert_eq!(options.labels, default_labels());
+            assert_eq!(options.min_score, 0.5);
+        }
+
+        #[test]
+        fn labels_and_score_are_parsed() {
+            let options = local_gliner_options(&[
+                "--local-gliner-labels",
+                "person,medical condition",
+                "--local-gliner-min-score",
+                "0.3",
+            ])
+            .unwrap();
+            assert_eq!(
+                options.labels,
+                vec!["person".to_string(), "medical condition".to_string()]
+            );
+            assert_eq!(options.min_score, 0.3);
+        }
+
+        #[test]
+        fn score_outside_the_unit_range_is_a_config_error() {
+            let err = local_gliner_options(&["--local-gliner-min-score", "1.5"]).unwrap_err();
+            assert!(matches!(err, AppError::RedacterConfigError { .. }), "{err}");
+            assert!(err.to_string().contains("1.5"), "{err}");
+        }
+
+        #[test]
+        fn an_empty_label_is_a_config_error() {
+            let err = local_gliner_options(&["--local-gliner-labels", "person,  "]).unwrap_err();
+            assert!(matches!(err, AppError::RedacterConfigError { .. }), "{err}");
         }
     }
 }

--- a/src/commands/copy_command.rs
+++ b/src/commands/copy_command.rs
@@ -645,7 +645,7 @@ mod tests {
     use tempfile::TempDir;
 
     const SAMPLE_DOCUMENTS_DIR: &str = TEST_DOCUMENTS_DIR;
-    const SAMPLE_FILE_NAMES: [&str; 8] = TEST_DOCUMENT_NAMES;
+    const SAMPLE_FILE_NAMES: [&str; 9] = TEST_DOCUMENT_NAMES;
     const SAMPLE_EMAIL: &str = TEST_DOCUMENT_SAMPLE_EMAIL;
     const SAMPLE_PHONE: &str = TEST_DOCUMENT_SAMPLE_PHONE;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -58,6 +58,9 @@ pub enum AppError {
     #[cfg(feature = "local-ner")]
     #[error("Local NER error: {0}")]
     LocalNerError(#[from] crate::redacters::local_ner::LocalNerError),
+    #[cfg(feature = "local-gliner")]
+    #[error("Local GLiNER error: {0}")]
+    LocalGlinerError(#[from] crate::redacters::local_gliner::LocalGlinerError),
     #[error("System error: {message}")]
     SystemError { message: String },
     #[error("System error: {message}")]

--- a/src/file_systems/local.rs
+++ b/src/file_systems/local.rs
@@ -312,7 +312,7 @@ mod tests {
             .into_iter()
             .map(|file_ref| (file_ref.relative_path.filename(), file_ref))
             .collect();
-        assert_eq!(files_by_name.len(), 8);
+        assert_eq!(files_by_name.len(), 9);
 
         let expected_media_types = [
             ("customer-note.txt", mime::TEXT_PLAIN),
@@ -323,6 +323,7 @@ mod tests {
             ("customer-form.pdf", mime::APPLICATION_PDF),
             ("dates-en.txt", mime::TEXT_PLAIN),
             ("false-positives-en.txt", mime::TEXT_PLAIN),
+            ("contextual-en.txt", mime::TEXT_PLAIN),
         ];
         for (name, expected_media_type) in expected_media_types {
             let file_ref = files_by_name

--- a/src/model_store/manifest.rs
+++ b/src/model_store/manifest.rs
@@ -12,6 +12,9 @@ pub enum ModelId {
     // `#[allow(dead_code)]` that would also hide a real regression.
     #[cfg(any(feature = "local-ner", test))]
     NerMultilingualHrl,
+    // Only the local-gliner feature resolves this one; gated for the same reason as `Ocrs`.
+    #[cfg(any(feature = "local-gliner", test))]
+    GlinerMultiPii,
 }
 
 /// One file of a model: where it comes from and what it must look like on disk.
@@ -73,10 +76,43 @@ static NER_MULTILINGUAL_HRL_FILES: [ModelFile; 3] = [
 ];
 
 /// A model that has never lived anywhere but the managed root.
-#[cfg(any(feature = "local-ner", test))]
+#[cfg(any(feature = "local-ner", feature = "local-gliner", test))]
 pub(super) fn no_legacy_dirs() -> Vec<PathBuf> {
     Vec::new()
 }
+
+#[cfg(any(feature = "local-gliner", test))]
+macro_rules! gliner_url {
+    ($path:literal) => {
+        concat!(
+            "https://huggingface.co/onnx-community/gliner_multi_pii-v1/resolve/",
+            "2e0397a7e8a250d76c37122232b3cbde42c8d629/",
+            $path
+        )
+    };
+}
+
+#[cfg(any(feature = "local-gliner", test))]
+static GLINER_MULTI_PII_FILES: [ModelFile; 3] = [
+    ModelFile {
+        name: "model.onnx",
+        url: gliner_url!("onnx/model.onnx"),
+        size: 1_157_129_714,
+        sha256: "7704865e414f24591da6aee08716a25677855bc8a84af81396d90e40df1e68d2",
+    },
+    ModelFile {
+        name: "tokenizer.json",
+        url: gliner_url!("tokenizer.json"),
+        size: 16_331_948,
+        sha256: "914bd3c8fb7b525af9e23b60d0ec7b1248ddb2b99014efd9c02ebeb022f8cab7",
+    },
+    ModelFile {
+        name: "gliner_config.json",
+        url: gliner_url!("gliner_config.json"),
+        size: 732,
+        sha256: "69e141f7fe1864e0d81ab0e542c68387d588db62393bcd93b471d54dcf0f5c16",
+    },
+];
 
 #[cfg(any(feature = "ocr", test))]
 static OCRS_FILES: [ModelFile; 2] = [
@@ -132,12 +168,24 @@ static NER_MULTILINGUAL_HRL: ModelManifest = ModelManifest {
     legacy_dirs: no_legacy_dirs,
 };
 
+#[cfg(any(feature = "local-gliner", test))]
+static GLINER_MULTI_PII: ModelManifest = ModelManifest {
+    dir_name: "gliner_multi_pii-v1",
+    needed_by: "The local-gliner redacter",
+    source: "https://huggingface.co/onnx-community/gliner_multi_pii-v1 (revision 2e0397a7)",
+    license: "Apache-2.0 (model and training data), backbone microsoft/mdeberta-v3-base MIT",
+    files: &GLINER_MULTI_PII_FILES,
+    legacy_dirs: no_legacy_dirs,
+};
+
 pub fn manifest(id: ModelId) -> &'static ModelManifest {
     match id {
         #[cfg(any(feature = "ocr", test))]
         ModelId::Ocrs => &OCRS,
         #[cfg(any(feature = "local-ner", test))]
         ModelId::NerMultilingualHrl => &NER_MULTILINGUAL_HRL,
+        #[cfg(any(feature = "local-gliner", test))]
+        ModelId::GlinerMultiPii => &GLINER_MULTI_PII,
     }
 }
 
@@ -204,6 +252,42 @@ mod tests {
         let total: u64 = manifest.files.iter().map(|f| f.size).sum();
         assert_eq!(total, 138_036_031);
         assert!((manifest.legacy_dirs)().is_empty());
+    }
+
+    #[test]
+    fn gliner_manifest_lists_the_three_pinned_files() {
+        let manifest = manifest(ModelId::GlinerMultiPii);
+        assert_eq!(manifest.dir_name, "gliner_multi_pii-v1");
+        assert_eq!(manifest.needed_by, "The local-gliner redacter");
+        let names: Vec<&str> = manifest.files.iter().map(|f| f.name).collect();
+        assert_eq!(
+            names,
+            ["model.onnx", "tokenizer.json", "gliner_config.json"]
+        );
+        let total: u64 = manifest.files.iter().map(|f| f.size).sum();
+        assert_eq!(total, 1_157_129_714 + 16_331_948 + 732);
+        assert!((manifest.legacy_dirs)().is_empty());
+    }
+
+    #[test]
+    fn gliner_urls_pin_the_revision_and_digests_are_hex() {
+        let manifest = manifest(ModelId::GlinerMultiPii);
+        for file in manifest.files {
+            assert!(
+                file.url.starts_with(
+                    "https://huggingface.co/onnx-community/gliner_multi_pii-v1/resolve/2e0397a7e8a250d76c37122232b3cbde42c8d629/"
+                ),
+                "{}",
+                file.url
+            );
+            assert!(file.url.ends_with(file.name), "{}", file.url);
+            assert_eq!(file.sha256.len(), 64, "{}", file.name);
+            assert!(
+                file.sha256.chars().all(|c| c.is_ascii_hexdigit()),
+                "{}",
+                file.name
+            );
+        }
     }
 
     #[test]

--- a/src/redacters/local_gliner/engine.rs
+++ b/src/redacters/local_gliner/engine.rs
@@ -447,6 +447,8 @@ mod tests {
     use crate::reporter::AppReporter;
     use console::Term;
 
+    /// `DownloadModels::No`: the 1.16 GB model is placed in the cache by hand for these tests
+    /// and must never be fetched over the network by a test run.
     async fn engine() -> GlinerEngine {
         let term = Term::stdout();
         let reporter = AppReporter::from(&term);

--- a/src/redacters/local_gliner/engine.rs
+++ b/src/redacters/local_gliner/engine.rs
@@ -1,0 +1,483 @@
+//! The rten and tokenizers side of the local GLiNER redacter: loads the pinned model once and
+//! scores windows for the pure pipeline.
+//!
+//! rten's ONNX loader downcasts every `int64`/`bool` graph input to `int32`, so every tensor
+//! built here is `i32` rather than the `int64`/`bool` the exported graph declares.
+
+use super::error::LocalGlinerError;
+use super::labels::batch_labels;
+use super::pipeline::{
+    candidates_to_findings, greedy_decode, score_document, GlinerOptions, Logits, WindowInputs,
+    WindowScorer, OVERLAP_WORDS,
+};
+use crate::model_store::ModelFiles;
+use crate::redacters::text_spans::{apply_redaction, merge_findings, Finding, REDACTED};
+use rten::{Model, NodeId};
+use rten_tensor::prelude::*;
+use rten_tensor::NdTensor;
+use std::path::Path;
+use tokenizers::Tokenizer;
+
+/// The fields of `gliner_config.json` the pipeline needs. The three string fields are
+/// validated rather than merely read: they name the pre/post-processing this engine
+/// implements, and a config file that disagrees would silently score with the wrong shapes.
+#[derive(Debug)]
+struct GlinerConfigValues {
+    max_len: usize,
+    max_width: usize,
+    max_types: usize,
+    ent_token: String,
+    sep_token: String,
+}
+
+fn read_config(path: &Path) -> Result<GlinerConfigValues, LocalGlinerError> {
+    let config_error = |reason: String| LocalGlinerError::Config {
+        path: path.display().to_string(),
+        reason,
+    };
+    let bytes = std::fs::read(path).map_err(|err| config_error(err.to_string()))?;
+    let config: serde_json::Value =
+        serde_json::from_slice(&bytes).map_err(|err| config_error(err.to_string()))?;
+
+    let field_usize = |name: &str| -> Result<usize, LocalGlinerError> {
+        config
+            .get(name)
+            .and_then(|value| value.as_u64())
+            .and_then(|value| usize::try_from(value).ok())
+            .ok_or_else(|| config_error(format!("no {name} number")))
+    };
+    let field_str = |name: &str| -> Result<String, LocalGlinerError> {
+        config
+            .get(name)
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| config_error(format!("no {name} string")))
+    };
+    let expect_str = |name: &str, expected: &str| -> Result<(), LocalGlinerError> {
+        let actual = field_str(name)?;
+        if actual != expected {
+            return Err(config_error(format!(
+                "{name} is `{actual}`, this engine only implements `{expected}`"
+            )));
+        }
+        Ok(())
+    };
+
+    let max_len = field_usize("max_len")?;
+    let max_width = field_usize("max_width")?;
+    let max_types = field_usize("max_types")?;
+    let ent_token = field_str("ent_token")?;
+    let sep_token = field_str("sep_token")?;
+    expect_str("span_mode", "markerV0")?;
+    expect_str("subtoken_pooling", "first")?;
+    expect_str("words_splitter_type", "whitespace")?;
+
+    if max_len <= 2 {
+        return Err(config_error(format!(
+            "max_len {max_len} leaves no room for a single text word"
+        )));
+    }
+    if max_width == 0 {
+        return Err(config_error("max_width is 0".to_string()));
+    }
+    if max_types == 0 {
+        return Err(config_error("max_types is 0".to_string()));
+    }
+
+    Ok(GlinerConfigValues {
+        max_len,
+        max_width,
+        max_types,
+        ent_token,
+        sep_token,
+    })
+}
+
+/// Loads `tokenizer.json` with truncation and padding turned off. The pipeline windows the
+/// word stream itself and needs every word: a `truncation` block left in the file would cut
+/// each text at one window and copy the rest of it unredacted.
+fn load_tokenizer(path: &Path) -> Result<Tokenizer, LocalGlinerError> {
+    let load_error = |reason: String| LocalGlinerError::TokenizerLoad {
+        path: path.display().to_string(),
+        reason,
+    };
+    let mut tokenizer = Tokenizer::from_file(path).map_err(|err| load_error(err.to_string()))?;
+    tokenizer
+        .with_truncation(None)
+        .map_err(|err| load_error(err.to_string()))?;
+    tokenizer.with_padding(None);
+    Ok(tokenizer)
+}
+
+fn special_token(tokenizer: &Tokenizer, token: &str) -> Result<u32, LocalGlinerError> {
+    tokenizer
+        .token_to_id(token)
+        .ok_or_else(|| LocalGlinerError::MissingSpecialToken {
+            token: token.to_string(),
+        })
+}
+
+fn graph_node(model: &Model, name: &str) -> Result<NodeId, LocalGlinerError> {
+    model
+        .find_node(name)
+        .ok_or_else(|| LocalGlinerError::MissingGraphNode {
+            name: name.to_string(),
+        })
+}
+
+/// The loaded model, tokenizer and config. `Send + Sync`: rten's `Model::run` and the
+/// tokenizer's `encode` take `&self`, so one engine behind an `Arc` serves every file.
+pub struct GlinerEngine {
+    model: Model,
+    tokenizer: Tokenizer,
+    cls: u32,
+    sep: u32,
+    ent: u32,
+    gliner_sep: u32,
+    max_len: usize,
+    max_width: usize,
+    max_types: usize,
+    input_ids: NodeId,
+    attention_mask: NodeId,
+    words_mask: NodeId,
+    text_lengths: NodeId,
+    span_idx: NodeId,
+    span_mask: NodeId,
+    logits: NodeId,
+}
+
+impl GlinerEngine {
+    /// Loads `gliner_config.json`, `tokenizer.json` and `model.onnx` from the resolved model
+    /// directory. Every missing or unexpected piece is a typed error naming it.
+    pub fn load(files: &ModelFiles) -> Result<Self, LocalGlinerError> {
+        let config = read_config(&files.path("gliner_config.json"))?;
+        let tokenizer = load_tokenizer(&files.path("tokenizer.json"))?;
+        let cls = special_token(&tokenizer, "[CLS]")?;
+        let sep = special_token(&tokenizer, "[SEP]")?;
+        let ent = special_token(&tokenizer, &config.ent_token)?;
+        let gliner_sep = special_token(&tokenizer, &config.sep_token)?;
+        let model_path = files.path("model.onnx");
+        let model =
+            Model::load_file(&model_path).map_err(|source| LocalGlinerError::ModelLoad {
+                path: model_path.display().to_string(),
+                source,
+            })?;
+        Ok(Self {
+            input_ids: graph_node(&model, "input_ids")?,
+            attention_mask: graph_node(&model, "attention_mask")?,
+            words_mask: graph_node(&model, "words_mask")?,
+            text_lengths: graph_node(&model, "text_lengths")?,
+            span_idx: graph_node(&model, "span_idx")?,
+            span_mask: graph_node(&model, "span_mask")?,
+            logits: graph_node(&model, "logits")?,
+            model,
+            tokenizer,
+            cls,
+            sep,
+            ent,
+            gliner_sep,
+            max_len: config.max_len,
+            max_width: config.max_width,
+            max_types: config.max_types,
+        })
+    }
+
+    /// Subtoken ids for one word or label string, without special tokens. `is_split_into_words`
+    /// in the Python processor is equivalent to encoding each pre-split word on its own, since
+    /// the tokenizer's Metaspace pre-tokenizer is configured with `prepend_scheme: always`.
+    fn subtoken_ids(&self, text: &str) -> Result<Vec<u32>, LocalGlinerError> {
+        self.tokenizer
+            .encode(text, false)
+            .map(|encoding| encoding.get_ids().to_vec())
+            .map_err(|err| LocalGlinerError::Encode {
+                text: text.to_string(),
+                reason: err.to_string(),
+            })
+    }
+
+    /// Byte spans of the selected labels, merged and sorted.
+    pub fn find(
+        &self,
+        text: &str,
+        options: &GlinerOptions,
+    ) -> Result<Vec<Finding>, LocalGlinerError> {
+        let words = super::pipeline::split_words(text);
+        if words.is_empty() {
+            return Ok(Vec::new());
+        }
+        let word_ids: Vec<Vec<u32>> = words
+            .iter()
+            .map(|word| self.subtoken_ids(word.text))
+            .collect::<Result<_, _>>()?;
+
+        let label_batches = batch_labels(&options.labels, self.max_types);
+        let mut label_ids: Vec<Vec<Vec<u32>>> = Vec::with_capacity(label_batches.len());
+        for batch in &label_batches {
+            let mut ids = Vec::with_capacity(batch.len());
+            for label in *batch {
+                ids.push(self.subtoken_ids(label)?);
+            }
+            label_ids.push(ids);
+        }
+
+        let candidates = score_document(
+            self,
+            self.cls,
+            self.sep,
+            self.ent,
+            self.gliner_sep,
+            &words,
+            &word_ids,
+            &label_batches,
+            &label_ids,
+            self.max_len,
+            self.max_width,
+            OVERLAP_WORDS,
+            options.min_score,
+        )?;
+        Ok(merge_findings(candidates_to_findings(greedy_decode(
+            candidates,
+        ))))
+    }
+
+    /// The text with every finding replaced by `[REDACTED]`, plus the findings.
+    pub fn redact_text(
+        &self,
+        text: &str,
+        options: &GlinerOptions,
+    ) -> Result<(String, Vec<Finding>), LocalGlinerError> {
+        let findings = self.find(text, options)?;
+        Ok((apply_redaction(text, &findings, REDACTED), findings))
+    }
+}
+
+/// `local_gliner::mod::LocalGlinerRedacter` shares one engine across `spawn_blocking` calls
+/// behind an `Arc`; this stops compiling the moment `Model` or `Tokenizer` stops being
+/// `Send + Sync`.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<GlinerEngine>();
+};
+
+impl WindowScorer for GlinerEngine {
+    fn score_window(
+        &self,
+        inputs: &WindowInputs,
+        num_labels: usize,
+    ) -> Result<Logits, LocalGlinerError> {
+        let n = inputs.ids.len();
+        let num_spans = inputs.span_idx.len();
+        let ids = NdTensor::from_data([1, n], inputs.ids.clone());
+        let attention = NdTensor::from_data([1, n], vec![1i32; n]);
+        let words_mask = NdTensor::from_data([1, n], inputs.words_mask.clone());
+        let text_lengths = NdTensor::from_data([1, 1], vec![inputs.num_words as i32]);
+        let span_idx_flat: Vec<i32> = inputs.span_idx.iter().flat_map(|pair| *pair).collect();
+        let span_idx = NdTensor::from_data([1, num_spans, 2], span_idx_flat);
+        let span_mask = NdTensor::from_data([1, num_spans], inputs.span_mask.clone());
+
+        let [output] = self
+            .model
+            .run_n(
+                vec![
+                    (self.input_ids, ids.view().into()),
+                    (self.attention_mask, attention.view().into()),
+                    (self.words_mask, words_mask.view().into()),
+                    (self.text_lengths, text_lengths.view().into()),
+                    (self.span_idx, span_idx.view().into()),
+                    (self.span_mask, span_mask.view().into()),
+                ],
+                [self.logits],
+                None,
+            )
+            .map_err(|err| LocalGlinerError::Inference {
+                reason: err.to_string(),
+            })?;
+
+        let output: NdTensor<f32, 4> =
+            output
+                .try_into()
+                .map_err(|err| LocalGlinerError::OutputShape {
+                    expected: "a rank-4 f32 tensor".to_string(),
+                    actual: format!("{err:?}"),
+                })?;
+        let [batch, num_words, max_width, out_labels] = output.shape();
+        if batch != 1 || num_words != inputs.num_words || out_labels != num_labels {
+            return Err(LocalGlinerError::OutputShape {
+                expected: format!("[1, {}, _, {num_labels}]", inputs.num_words),
+                actual: format!("[{batch}, {num_words}, {max_width}, {out_labels}]"),
+            });
+        }
+        Ok(Logits {
+            num_words,
+            max_width,
+            num_labels: out_labels,
+            data: output.to_vec(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REAL_CONFIG: &str = r#"{
+  "class_token_index": 250103,
+  "max_len": 384,
+  "max_width": 12,
+  "max_types": 25,
+  "ent_token": "<<ENT>>",
+  "sep_token": "<<SEP>>",
+  "span_mode": "markerV0",
+  "subtoken_pooling": "first",
+  "words_splitter_type": "whitespace"
+}"#;
+
+    fn config_file(contents: &str) -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), contents).unwrap();
+        file
+    }
+
+    #[test]
+    fn read_config_takes_the_shape_fields_from_the_real_file() {
+        let file = config_file(REAL_CONFIG);
+        let config = read_config(file.path()).unwrap();
+        assert_eq!(config.max_len, 384);
+        assert_eq!(config.max_width, 12);
+        assert_eq!(config.max_types, 25);
+        assert_eq!(config.ent_token, "<<ENT>>");
+        assert_eq!(config.sep_token, "<<SEP>>");
+    }
+
+    #[test]
+    fn read_config_names_the_file_and_the_missing_key() {
+        let file = config_file(r#"{"max_len": 384}"#);
+        let err = read_config(file.path()).unwrap_err();
+        match &err {
+            LocalGlinerError::Config { path, reason } => {
+                assert_eq!(path, &file.path().display().to_string());
+                assert!(reason.contains("max_width"), "{reason}");
+            }
+            other => panic!("expected Config, got {other}"),
+        }
+
+        let missing = Path::new("/nonexistent/gliner_config.json");
+        assert!(matches!(
+            read_config(missing).unwrap_err(),
+            LocalGlinerError::Config { .. }
+        ));
+    }
+
+    #[test]
+    fn read_config_rejects_an_unsupported_span_mode() {
+        let json = REAL_CONFIG.replace("markerV0", "other");
+        let file = config_file(&json);
+        let err = read_config(file.path()).unwrap_err();
+        match &err {
+            LocalGlinerError::Config { reason, .. } => {
+                assert!(reason.contains("span_mode"), "{reason}");
+                assert!(reason.contains("markerV0"), "{reason}");
+            }
+            other => panic!("expected Config, got {other}"),
+        }
+    }
+
+    #[test]
+    fn read_config_rejects_a_zero_shape_field() {
+        let json = REAL_CONFIG.replace("\"max_width\": 12", "\"max_width\": 0");
+        let file = config_file(&json);
+        assert!(matches!(
+            read_config(file.path()).unwrap_err(),
+            LocalGlinerError::Config { .. }
+        ));
+    }
+
+    /// A tokenizer.json carrying a `truncation` block, the shape a legacy or hand-placed copy
+    /// can still have: one word per token, and every text cut at 8 tokens unless the loader
+    /// turns truncation off.
+    fn truncating_tokenizer_file() -> tempfile::NamedTempFile {
+        let vocab: String = (0..40)
+            .map(|id| format!("\"w{id}\": {id}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let json = format!(
+            r#"{{
+  "version": "1.0",
+  "truncation": {{"direction": "Right", "max_length": 8, "strategy": "LongestFirst", "stride": 0}},
+  "padding": null,
+  "added_tokens": [],
+  "normalizer": null,
+  "pre_tokenizer": {{"type": "Whitespace"}},
+  "post_processor": null,
+  "decoder": null,
+  "model": {{"type": "WordLevel", "vocab": {{{vocab}, "[UNK]": 40}}, "unk_token": "[UNK]"}}
+}}"#
+        );
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), json).unwrap();
+        file
+    }
+
+    #[test]
+    fn the_loaded_tokenizer_never_truncates_a_long_text() {
+        let file = truncating_tokenizer_file();
+        let tokenizer = load_tokenizer(file.path()).unwrap();
+        let text: Vec<String> = (0..30).map(|id| format!("w{id}")).collect();
+        let text = text.join(" ");
+        let encoding = tokenizer.encode(text.as_str(), false).unwrap();
+        assert_eq!(
+            encoding.get_ids().len(),
+            30,
+            "the truncation block in the file must be turned off at load"
+        );
+    }
+
+    #[test]
+    fn a_missing_tokenizer_file_names_itself() {
+        let err = load_tokenizer(Path::new("/nonexistent/tokenizer.json")).unwrap_err();
+        match &err {
+            LocalGlinerError::TokenizerLoad { path, .. } => {
+                assert_eq!(path, "/nonexistent/tokenizer.json")
+            }
+            other => panic!("expected TokenizerLoad, got {other}"),
+        }
+    }
+
+    use crate::model_store::{DownloadModels, ModelId, ModelStore, ModelStoreOptions};
+    use crate::reporter::AppReporter;
+    use console::Term;
+
+    async fn engine() -> GlinerEngine {
+        let term = Term::stdout();
+        let reporter = AppReporter::from(&term);
+        let options = ModelStoreOptions {
+            download: DownloadModels::No,
+            models_dir: None,
+        };
+        let store = ModelStore::new(&options, &reporter);
+        let files = store.resolve(ModelId::GlinerMultiPii).await.unwrap();
+        GlinerEngine::load(&files).unwrap()
+    }
+
+    fn default_options() -> GlinerOptions {
+        GlinerOptions {
+            labels: super::super::labels::default_labels(),
+            min_score: 0.5,
+        }
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "ci-local-gliner"), ignore)]
+    async fn loads_the_pinned_model_and_scores_a_window() {
+        let engine = engine().await;
+        assert_eq!(engine.max_width, 12);
+        assert_eq!(engine.max_types, 25);
+        let findings = engine
+            .find("Alice Smith called from London.", &default_options())
+            .unwrap();
+        assert!(
+            findings.iter().any(|f| f.rule.as_str() == "person"),
+            "{findings:?}"
+        );
+    }
+}

--- a/src/redacters/local_gliner/error.rs
+++ b/src/redacters/local_gliner/error.rs
@@ -1,0 +1,40 @@
+/// Failures of the local GLiNER redacter. Every variant names what was wrong: the file, the
+/// config field, the graph node, the token, the shape, or the value the user passed.
+#[derive(Debug, thiserror::Error)]
+pub enum LocalGlinerError {
+    #[error("cannot load GLiNER model {path}: {source}")]
+    ModelLoad {
+        path: String,
+        #[source]
+        source: rten::LoadError,
+    },
+    #[error("cannot load tokenizer {path}: {reason}")]
+    TokenizerLoad { path: String, reason: String },
+    #[error("model config {path}: {reason}")]
+    Config { path: String, reason: String },
+    #[error("model graph has no node named `{name}`")]
+    MissingGraphNode { name: String },
+    #[error("tokenizer has no `{token}` token")]
+    MissingSpecialToken { token: String },
+    #[error("cannot tokenize `{text}`: {reason}")]
+    Encode { text: String, reason: String },
+    #[error("model inference failed: {reason}")]
+    Inference { reason: String },
+    #[error("model output has shape {actual}, expected {expected}")]
+    OutputShape { expected: String, actual: String },
+    #[error("inference task failed: {reason}")]
+    InferenceTask { reason: String },
+    #[error("no labels given to the local-gliner redacter")]
+    NoLabels,
+    #[error("local-gliner label is empty or all whitespace")]
+    EmptyLabel,
+    #[error("local-gliner minimum score {value} is outside 0.0..=1.0")]
+    InvalidMinScore { value: f32 },
+    #[error(
+        "a label batch prompt of {prompt_tokens} tokens leaves no room for any text word within max_len {max_len}"
+    )]
+    PromptTooLong {
+        prompt_tokens: usize,
+        max_len: usize,
+    },
+}

--- a/src/redacters/local_gliner/labels.rs
+++ b/src/redacters/local_gliner/labels.rs
@@ -1,0 +1,80 @@
+//! The default zero-shot label set fed to the model as prompt text.
+//!
+//! `gliner_multi_pii-v1` has no fixed label taxonomy: any free-text label works as a prompt.
+//! This list is PII only. `organization` is deliberately absent: measured against this model,
+//! it over-redacts team and desk names (`Marketing team`, `The Support Desk`) that are not PII.
+
+pub const DEFAULT_LABELS: &[&str] = &[
+    "person",
+    "address",
+    "email",
+    "phone number",
+    "date of birth",
+    "passport number",
+    "national id number",
+    "credit card number",
+    "iban",
+    "ip address",
+    "username",
+    "medical condition",
+    "postal code",
+    "license plate number",
+];
+
+pub fn default_labels() -> Vec<String> {
+    DEFAULT_LABELS
+        .iter()
+        .map(|label| label.to_string())
+        .collect()
+}
+
+/// Splits `labels` into batches of at most `max_types`, the model's limit on how many entity
+/// types one forward pass can score. Each batch becomes an independent prompt over the same
+/// windows; callers union the resulting spans.
+pub fn batch_labels(labels: &[String], max_types: usize) -> Vec<&[String]> {
+    if max_types == 0 {
+        return Vec::new();
+    }
+    labels.chunks(max_types).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_labels_has_no_organization() {
+        let labels = default_labels();
+        assert!(!labels.is_empty());
+        assert!(
+            !labels.iter().any(|label| label == "organization"),
+            "{labels:?}"
+        );
+    }
+
+    #[test]
+    fn batches_respect_max_types_and_cover_every_label() {
+        let labels: Vec<String> = (0..60).map(|i| format!("label{i}")).collect();
+        let batches = batch_labels(&labels, 25);
+        assert_eq!(batches.len(), 3);
+        assert_eq!(batches[0].len(), 25);
+        assert_eq!(batches[1].len(), 25);
+        assert_eq!(batches[2].len(), 10);
+        let total: usize = batches.iter().map(|b| b.len()).sum();
+        assert_eq!(total, labels.len());
+    }
+
+    #[test]
+    fn a_single_small_batch_is_not_split() {
+        let labels = default_labels();
+        let batches = batch_labels(&labels, 25);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), labels.len());
+    }
+
+    #[test]
+    fn zero_max_types_yields_no_batches() {
+        let labels = default_labels();
+        assert!(batch_labels(&labels, 0).is_empty());
+    }
+}

--- a/src/redacters/local_gliner/mod.rs
+++ b/src/redacters/local_gliner/mod.rs
@@ -1,0 +1,521 @@
+//! Offline zero-shot PII redacter: a GLiNER span model on rten scores free-text labels
+//! against a document; the pure pipeline turns its logits into byte spans.
+
+mod engine;
+mod error;
+pub mod labels;
+pub mod pipeline;
+
+pub use error::LocalGlinerError;
+
+use crate::args::RedacterType;
+use crate::file_systems::FileSystemRef;
+use crate::model_store::{ModelId, ModelStore};
+use crate::redacters::text_spans::{apply_redaction, Finding, REDACTED};
+use crate::redacters::{
+    text_or_table_support, unsupported_type_error, RedactSupport, Redacter, RedacterDataItem,
+    RedacterDataItemContent,
+};
+use crate::reporter::AppReporter;
+use crate::AppResult;
+use engine::GlinerEngine;
+use pipeline::GlinerOptions;
+use rvstruct::ValueStruct;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LocalGlinerRedacterOptions {
+    pub labels: Vec<String>,
+    pub min_score: f32,
+}
+
+impl LocalGlinerRedacterOptions {
+    /// Rejects an empty or all-whitespace label, an empty label list and a score outside
+    /// `0.0..=1.0` (NaN included). Every label is trimmed, since the model reads it as
+    /// prompt text and leading or trailing whitespace changes nothing but the token count.
+    pub fn validated(labels: Vec<String>, min_score: f32) -> Result<Self, LocalGlinerError> {
+        if labels.is_empty() {
+            return Err(LocalGlinerError::NoLabels);
+        }
+        let mut trimmed = Vec::with_capacity(labels.len());
+        for label in labels {
+            let label = label.trim().to_string();
+            if label.is_empty() {
+                return Err(LocalGlinerError::EmptyLabel);
+            }
+            trimmed.push(label);
+        }
+        if !(0.0..=1.0).contains(&min_score) {
+            return Err(LocalGlinerError::InvalidMinScore { value: min_score });
+        }
+        Ok(Self {
+            labels: trimmed,
+            min_score,
+        })
+    }
+}
+
+/// Redacts every table cell that could hold a labelled span, leaving the rest byte for byte.
+/// The predicate is "holds no letter", not "is a number": a cell without one cannot hold text
+/// worth scoring and never reaches the model, which would cost a tokenizer pass and a forward
+/// pass to find nothing.
+///
+/// Each cell is scored with its column header in front of it, `"city: Madrid"` rather than
+/// `"Madrid"`: a one-word cell gives the model no sentence, and short bare values are tagged
+/// at a lower score than the same value read as a sentence. The prefix is scoring context
+/// only. Findings are mapped back onto the cell by `shift_into_cell` and the redaction is
+/// applied to the original cell text, so no header text can reach the output.
+fn redact_rows<F>(
+    headers: &[String],
+    rows: Vec<Vec<String>>,
+    mut find_in: F,
+) -> Result<(Vec<Vec<String>>, usize), LocalGlinerError>
+where
+    F: FnMut(&str) -> Result<Vec<Finding>, LocalGlinerError>,
+{
+    let mut findings = 0usize;
+    let mut redacted_rows = Vec::with_capacity(rows.len());
+    for row in rows {
+        let mut redacted_row = Vec::with_capacity(row.len());
+        for (column, cell) in row.into_iter().enumerate() {
+            if !cell.chars().any(char::is_alphabetic) {
+                redacted_row.push(cell);
+                continue;
+            }
+            // A row wider than the header list, or an empty header, leaves the cell alone.
+            let prefix = match headers.get(column) {
+                Some(header) if !header.is_empty() => format!("{header}: "),
+                _ => String::new(),
+            };
+            let scored = if prefix.is_empty() {
+                find_in(&cell)?
+            } else {
+                find_in(&format!("{prefix}{cell}"))?
+            };
+            let in_cell = shift_into_cell(scored, prefix.len());
+            findings += in_cell.len();
+            redacted_row.push(apply_redaction(&cell, &in_cell, REDACTED));
+        }
+        redacted_rows.push(redacted_row);
+    }
+    Ok((redacted_rows, findings))
+}
+
+/// Maps findings on `"{prefix}{cell}"` back onto `cell`. A finding that ends inside the
+/// prefix is the model matching the header itself and is dropped; one that crosses the
+/// boundary keeps only the part that falls in the cell. `prefix_len` is a byte length and the
+/// cell starts exactly there, so every clamped offset stays on a character boundary.
+fn shift_into_cell(findings: Vec<Finding>, prefix_len: usize) -> Vec<Finding> {
+    findings
+        .into_iter()
+        .filter(|finding| finding.end > prefix_len)
+        .map(|mut finding| {
+            finding.start = finding.start.max(prefix_len) - prefix_len;
+            finding.end -= prefix_len;
+            finding
+        })
+        .collect()
+}
+
+/// Offline GLiNER redacter. The engine is loaded once per run and shared through an `Arc`,
+/// so inference can run on a blocking thread while the async pipeline waits.
+#[derive(Clone)]
+pub struct LocalGlinerRedacter<'a> {
+    engine: Arc<GlinerEngine>,
+    options: GlinerOptions,
+    reporter: &'a AppReporter<'a>,
+}
+
+impl<'a> LocalGlinerRedacter<'a> {
+    pub async fn new(
+        options: LocalGlinerRedacterOptions,
+        reporter: &'a AppReporter<'a>,
+        models: &ModelStore<'_>,
+    ) -> AppResult<Self> {
+        let files = models.resolve(ModelId::GlinerMultiPii).await?;
+        reporter.report(format!(
+            "Loading local GLiNER model from {}",
+            files.dir().to_string_lossy()
+        ))?;
+        let engine = GlinerEngine::load(&files)?;
+        Ok(Self {
+            engine: Arc::new(engine),
+            options: GlinerOptions {
+                labels: options.labels,
+                min_score: options.min_score,
+            },
+            reporter,
+        })
+    }
+
+    /// Runs `work` on the blocking pool with a shared handle to the engine.
+    async fn run_blocking<T, F>(&self, work: F) -> AppResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&GlinerEngine, &GlinerOptions) -> Result<T, LocalGlinerError> + Send + 'static,
+    {
+        let engine = Arc::clone(&self.engine);
+        let options = self.options.clone();
+        let result = tokio::task::spawn_blocking(move || work(&engine, &options))
+            .await
+            .map_err(|err| LocalGlinerError::InferenceTask {
+                reason: err.to_string(),
+            })?;
+        Ok(result?)
+    }
+}
+
+impl<'a> Redacter for LocalGlinerRedacter<'a> {
+    async fn redact(&self, input: RedacterDataItem) -> AppResult<RedacterDataItem> {
+        let (content, findings) = match input.content {
+            RedacterDataItemContent::Value(text) => {
+                let (redacted, findings) = self
+                    .run_blocking(move |engine, options| {
+                        let (redacted, findings) = engine.redact_text(&text, options)?;
+                        Ok((redacted, findings.len()))
+                    })
+                    .await?;
+                (RedacterDataItemContent::Value(redacted), findings)
+            }
+            RedacterDataItemContent::Table { headers, rows } => {
+                let (headers, rows, findings) = self
+                    .run_blocking(move |engine, options| {
+                        let (rows, findings) =
+                            redact_rows(&headers, rows, |text| engine.find(text, options))?;
+                        Ok((headers, rows, findings))
+                    })
+                    .await?;
+                (RedacterDataItemContent::Table { headers, rows }, findings)
+            }
+            RedacterDataItemContent::Image { .. } | RedacterDataItemContent::Pdf { .. } => {
+                return Err(unsupported_type_error())
+            }
+        };
+        if findings > 0 {
+            self.reporter.report_debug(format!(
+                "local-gliner: {} finding(s) in {}",
+                findings,
+                input.file_ref.relative_path.value()
+            ));
+        }
+        Ok(RedacterDataItem {
+            content,
+            file_ref: input.file_ref,
+        })
+    }
+
+    async fn redact_support(&self, file_ref: &FileSystemRef) -> AppResult<RedactSupport> {
+        Ok(text_or_table_support(file_ref))
+    }
+
+    fn redacter_type(&self) -> RedacterType {
+        RedacterType::LocalGliner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_store::{DownloadModels, ModelStoreOptions};
+    use crate::redacters::test_support::TEST_DOCUMENTS_DIR;
+    use crate::redacters::text_spans::RuleName;
+    use console::Term;
+    use mime::Mime;
+
+    #[test]
+    fn options_default_labels_and_reject_bad_values() {
+        let options = LocalGlinerRedacterOptions::validated(labels::default_labels(), 0.5).unwrap();
+        assert_eq!(options.labels, labels::default_labels());
+        assert_eq!(options.min_score, 0.5);
+        assert!(LocalGlinerRedacterOptions::validated(vec!["person".to_string()], 0.0).is_ok());
+        assert!(LocalGlinerRedacterOptions::validated(vec!["person".to_string()], 1.0).is_ok());
+
+        let err = LocalGlinerRedacterOptions::validated(Vec::new(), 0.5).unwrap_err();
+        assert!(matches!(err, LocalGlinerError::NoLabels), "{err}");
+
+        let err = LocalGlinerRedacterOptions::validated(vec!["  ".to_string()], 0.5).unwrap_err();
+        assert!(matches!(err, LocalGlinerError::EmptyLabel), "{err}");
+
+        for bad in [-0.1_f32, 1.5, f32::NAN] {
+            let err =
+                LocalGlinerRedacterOptions::validated(vec!["person".to_string()], bad).unwrap_err();
+            assert!(
+                matches!(err, LocalGlinerError::InvalidMinScore { .. }),
+                "{bad}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn labels_are_trimmed() {
+        let options =
+            LocalGlinerRedacterOptions::validated(vec![" email \n".to_string()], 0.5).unwrap();
+        assert_eq!(options.labels, vec!["email".to_string()]);
+    }
+
+    /// The redacter answers `redact_support` with the shared text/table rule, so the media
+    /// types it accepts are asserted through the very function it delegates to.
+    #[test]
+    fn supports_text_and_csv_but_not_images_or_pdf() {
+        let supports = |media_type: Option<Mime>| {
+            text_or_table_support(&FileSystemRef {
+                relative_path: "sample".into(),
+                media_type,
+                file_size: None,
+            })
+        };
+        assert_eq!(supports(Some(mime::TEXT_PLAIN)), RedactSupport::Supported);
+        assert_eq!(
+            supports(Some(mime::APPLICATION_JSON)),
+            RedactSupport::Supported
+        );
+        assert_eq!(supports(Some(mime::TEXT_CSV)), RedactSupport::Supported);
+        assert_eq!(supports(Some(mime::IMAGE_PNG)), RedactSupport::Unsupported);
+        assert_eq!(
+            supports(Some(mime::APPLICATION_PDF)),
+            RedactSupport::Unsupported
+        );
+        assert_eq!(supports(None), RedactSupport::Unsupported);
+    }
+
+    fn finding(start: usize, end: usize) -> Finding {
+        Finding {
+            start,
+            end,
+            rule: RuleName::new("person"),
+        }
+    }
+
+    fn run_row(
+        headers: &[&str],
+        row: &[&str],
+        replies: Vec<Vec<Finding>>,
+    ) -> (Vec<String>, Vec<String>, usize) {
+        let headers: Vec<String> = headers.iter().map(|h| h.to_string()).collect();
+        let rows = vec![row.iter().map(|cell| cell.to_string()).collect::<Vec<_>>()];
+        let mut seen: Vec<String> = Vec::new();
+        let mut replies = replies.into_iter();
+        let (rows, findings) = redact_rows(&headers, rows, |text| {
+            seen.push(text.to_string());
+            Ok(replies.next().unwrap_or_default())
+        })
+        .unwrap();
+        (rows.into_iter().next().unwrap(), seen, findings)
+    }
+
+    #[test]
+    fn cells_without_letters_never_reach_the_model() {
+        let headers: Vec<String> = ["id", "full_name", "amount"]
+            .iter()
+            .map(|h| h.to_string())
+            .collect();
+        let rows = vec![
+            vec![
+                "1".to_string(),
+                "Maria Garcia Lopez".to_string(),
+                " 42.5 ".to_string(),
+            ],
+            vec!["-7".to_string(), "Osaka".to_string(), String::new()],
+        ];
+        let mut seen: Vec<String> = Vec::new();
+        let (redacted, findings) = redact_rows(&headers, rows, |text| {
+            seen.push(text.to_string());
+            Ok(vec![finding(text.len() - 5, text.len())])
+        })
+        .unwrap();
+        assert_eq!(seen, ["full_name: Maria Garcia Lopez", "full_name: Osaka"]);
+        assert_eq!(findings, 2);
+        assert_eq!(
+            redacted,
+            vec![
+                vec!["1", "Maria Garcia [REDACTED]", " 42.5 "],
+                vec!["-7", "[REDACTED]", ""],
+            ]
+        );
+    }
+
+    #[test]
+    fn the_column_header_is_given_to_the_model_and_never_reaches_the_output() {
+        let (row, seen, findings) = run_row(
+            &["id", "city"],
+            &["1", "Madrid"],
+            vec![vec![finding(6, 12)]],
+        );
+        assert_eq!(seen, ["city: Madrid"]);
+        assert_eq!(row, ["1", "[REDACTED]"]);
+        assert_eq!(findings, 1);
+        assert!(!row.iter().any(|cell| cell.contains("city")), "{row:?}");
+    }
+
+    #[test]
+    fn findings_in_the_prefix_are_dropped_and_crossing_ones_are_clamped() {
+        let (row, seen, findings) = run_row(&["city"], &["Madrid"], vec![vec![finding(0, 4)]]);
+        assert_eq!(seen, ["city: Madrid"]);
+        assert_eq!(row, ["Madrid"]);
+        assert_eq!(findings, 0);
+
+        let (row, _, findings) = run_row(&["city"], &["Madrid"], vec![vec![finding(3, 9)]]);
+        assert_eq!(row, ["[REDACTED]rid"]);
+        assert_eq!(findings, 1);
+
+        let (row, _, findings) = run_row(&["city"], &["Madrid"], vec![vec![finding(8, 12)]]);
+        assert_eq!(row, ["Ma[REDACTED]"]);
+        assert_eq!(findings, 1);
+    }
+
+    #[test]
+    fn a_cell_with_no_header_is_scored_on_its_own() {
+        let (row, seen, findings) = run_row(&[""], &["Madrid"], vec![vec![finding(0, 6)]]);
+        assert_eq!(seen, ["Madrid"]);
+        assert_eq!(row, ["[REDACTED]"]);
+        assert_eq!(findings, 1);
+
+        let (row, seen, _) = run_row(
+            &["city"],
+            &["Madrid", "Osaka"],
+            vec![vec![], vec![finding(0, 5)]],
+        );
+        assert_eq!(seen, ["city: Madrid", "Osaka"]);
+        assert_eq!(row, ["Madrid", "[REDACTED]"]);
+    }
+
+    async fn redacter<'a>(reporter: &'a AppReporter<'a>) -> LocalGlinerRedacter<'a> {
+        let options = ModelStoreOptions {
+            download: DownloadModels::No,
+            models_dir: None,
+        };
+        let store = ModelStore::new(&options, reporter);
+        let options = LocalGlinerRedacterOptions::validated(labels::default_labels(), 0.5).unwrap();
+        LocalGlinerRedacter::new(options, reporter, &store)
+            .await
+            .unwrap()
+    }
+
+    fn item(name: &str, media_type: Mime, content: RedacterDataItemContent) -> RedacterDataItem {
+        RedacterDataItem {
+            content,
+            file_ref: FileSystemRef {
+                relative_path: name.into(),
+                media_type: Some(media_type),
+                file_size: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "ci-local-gliner"), ignore)]
+    async fn redacts_the_pii_in_the_customer_note_and_keeps_the_order_and_time() {
+        let term = Term::stdout();
+        let reporter = AppReporter::from(&term);
+        let redacter = redacter(&reporter).await;
+        assert_eq!(redacter.redacter_type(), RedacterType::LocalGliner);
+        let text =
+            std::fs::read_to_string(format!("{TEST_DOCUMENTS_DIR}customer-note.txt")).unwrap();
+        let redacted = redacter
+            .redact(item(
+                "customer-note.txt",
+                mime::TEXT_PLAIN,
+                RedacterDataItemContent::Value(text),
+            ))
+            .await
+            .unwrap();
+        let RedacterDataItemContent::Value(out) = redacted.content else {
+            panic!("text stays text");
+        };
+        for pii in [
+            "John Michael Smith",
+            "john.smith@example.com",
+            "+1 (555) 123-4567",
+            "14 March 1985",
+            "221B Baker Street, London NW1 6XE",
+            "4111 1111 1111 1111",
+        ] {
+            assert!(!out.contains(pii), "{pii} survived:\n{out}");
+        }
+        assert!(out.contains("#A-10422"), "{out}");
+        assert!(out.contains("6pm"), "{out}");
+        assert!(out.contains("[REDACTED]"), "{out}");
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "ci-local-gliner"), ignore)]
+    async fn redacts_the_contextual_fixture_and_keeps_the_non_pii_controls() {
+        let term = Term::stdout();
+        let reporter = AppReporter::from(&term);
+        let redacter = redacter(&reporter).await;
+        let fixture_path = format!(
+            "{}/.claude/plans/2026-09-08-local-llm-spike-archive/experiments/spike-fixtures/contextual-en.txt",
+            std::env::var("HOME").expect("HOME is set")
+        );
+        let text = std::fs::read_to_string(&fixture_path)
+            .unwrap_or_else(|err| panic!("read {fixture_path}: {err}"));
+        let redacted = redacter
+            .redact(item(
+                "contextual-en.txt",
+                mime::TEXT_PLAIN,
+                RedacterDataItemContent::Value(text),
+            ))
+            .await
+            .unwrap();
+        let RedacterDataItemContent::Value(out) = redacted.content else {
+            panic!("text stays text");
+        };
+        for pii in [
+            "jonas petersen",
+            "type 2 diabetes",
+            "12/03/1984",
+            "@mira_k84",
+            "mkowalczyk",
+            "14 Rosewood Lane, Kettering",
+            "Mira Kowalczyk",
+        ] {
+            assert!(!out.contains(pii), "{pii} survived:\n{out}");
+        }
+        assert!(out.contains("Apple Watch"), "{out}");
+        assert!(out.contains("The Support Desk"), "{out}");
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "ci-local-gliner"), ignore)]
+    async fn redacts_table_cells_behind_their_column_headers() {
+        let term = Term::stdout();
+        let reporter = AppReporter::from(&term);
+        let redacter = redacter(&reporter).await;
+        let redacted = redacter
+            .redact(item(
+                "customers.csv",
+                mime::TEXT_CSV,
+                RedacterDataItemContent::Table {
+                    headers: vec![
+                        "id".to_string(),
+                        "full_name".to_string(),
+                        "email".to_string(),
+                    ],
+                    rows: vec![
+                        vec![
+                            "1".to_string(),
+                            "Maria Garcia Lopez".to_string(),
+                            "maria.garcia@example.org".to_string(),
+                        ],
+                        vec![
+                            "2".to_string(),
+                            "Akira Tanaka".to_string(),
+                            "akira.tanaka@example.net".to_string(),
+                        ],
+                    ],
+                },
+            ))
+            .await
+            .unwrap();
+        let RedacterDataItemContent::Table { headers, rows } = redacted.content else {
+            panic!("table stays table");
+        };
+        assert_eq!(headers, vec!["id", "full_name", "email"]);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0][0], "1");
+        assert_eq!(rows[1][0], "2");
+        for cell in rows.iter().flatten() {
+            assert!(!cell.contains('@'), "{cell:?}");
+        }
+    }
+}

--- a/src/redacters/local_gliner/mod.rs
+++ b/src/redacters/local_gliner/mod.rs
@@ -56,9 +56,9 @@ impl LocalGlinerRedacterOptions {
 }
 
 /// Redacts every table cell that could hold a labelled span, leaving the rest byte for byte.
-/// The predicate is "holds no letter", not "is a number": a cell without one cannot hold text
-/// worth scoring and never reaches the model, which would cost a tokenizer pass and a forward
-/// pass to find nothing.
+/// Only an empty or whitespace-only cell is skipped: unlike a name-only NER model, GLiNER's
+/// default labels include phone number, credit card number, iban and other digit-only spans,
+/// so a "holds no letter" skip would hide every phone number and card number in a table.
 ///
 /// Each cell is scored with its column header in front of it, `"city: Madrid"` rather than
 /// `"Madrid"`: a one-word cell gives the model no sentence, and short bare values are tagged
@@ -78,7 +78,7 @@ where
     for row in rows {
         let mut redacted_row = Vec::with_capacity(row.len());
         for (column, cell) in row.into_iter().enumerate() {
-            if !cell.chars().any(char::is_alphabetic) {
+            if cell.trim().is_empty() {
                 redacted_row.push(cell);
                 continue;
             }
@@ -304,8 +304,8 @@ mod tests {
     }
 
     #[test]
-    fn cells_without_letters_never_reach_the_model() {
-        let headers: Vec<String> = ["id", "full_name", "amount"]
+    fn digits_only_cells_are_scored() {
+        let headers: Vec<String> = ["id", "full_name", "phone"]
             .iter()
             .map(|h| h.to_string())
             .collect();
@@ -313,7 +313,7 @@ mod tests {
             vec![
                 "1".to_string(),
                 "Maria Garcia Lopez".to_string(),
-                " 42.5 ".to_string(),
+                "+34 612 345 678".to_string(),
             ],
             vec!["-7".to_string(), "Osaka".to_string(), String::new()],
         ];
@@ -323,13 +323,26 @@ mod tests {
             Ok(vec![finding(text.len() - 5, text.len())])
         })
         .unwrap();
-        assert_eq!(seen, ["full_name: Maria Garcia Lopez", "full_name: Osaka"]);
-        assert_eq!(findings, 2);
+        assert_eq!(
+            seen,
+            [
+                "id: 1",
+                "full_name: Maria Garcia Lopez",
+                "phone: +34 612 345 678",
+                "id: -7",
+                "full_name: Osaka",
+            ]
+        );
+        assert_eq!(findings, 5);
         assert_eq!(
             redacted,
             vec![
-                vec!["1", "Maria Garcia [REDACTED]", " 42.5 "],
-                vec!["-7", "[REDACTED]", ""],
+                vec![
+                    "[REDACTED]",
+                    "Maria Garcia [REDACTED]",
+                    "+34 612 34[REDACTED]"
+                ],
+                vec!["[REDACTED]", "[REDACTED]", ""],
             ]
         );
     }
@@ -339,9 +352,9 @@ mod tests {
         let (row, seen, findings) = run_row(
             &["id", "city"],
             &["1", "Madrid"],
-            vec![vec![finding(6, 12)]],
+            vec![vec![], vec![finding(6, 12)]],
         );
-        assert_eq!(seen, ["city: Madrid"]);
+        assert_eq!(seen, ["id: 1", "city: Madrid"]);
         assert_eq!(row, ["1", "[REDACTED]"]);
         assert_eq!(findings, 1);
         assert!(!row.iter().any(|cell| cell.contains("city")), "{row:?}");
@@ -363,6 +376,36 @@ mod tests {
         assert_eq!(findings, 1);
     }
 
+    /// The prefix is cut off by byte length, and a German header is one byte longer than it
+    /// looks: `Straße: ` is 8 characters and 9 bytes. A shift counted in characters would move
+    /// every finding one byte into the cell and cut a multi-byte one in half.
+    #[test]
+    fn a_non_ascii_header_shifts_the_findings_by_bytes() {
+        let prefix = "Straße: ".len();
+        assert_eq!(prefix, 9, "the header is one byte longer than it is wide");
+        let (row, seen, findings) = run_row(
+            &["Straße"],
+            &["Königsallee"],
+            vec![vec![finding(prefix, prefix + "Königsallee".len())]],
+        );
+        assert_eq!(seen, ["Straße: Königsallee"]);
+        assert_eq!(row, ["[REDACTED]"]);
+        assert_eq!(findings, 1);
+
+        // An ASCII header in front of a multi-byte cell: only the second word is tagged.
+        let (row, seen, findings) = run_row(
+            &["Stadt"],
+            &["München Süd"],
+            vec![vec![finding(
+                "Stadt: München ".len(),
+                "Stadt: München Süd".len(),
+            )]],
+        );
+        assert_eq!(seen, ["Stadt: München Süd"]);
+        assert_eq!(row, ["München [REDACTED]"]);
+        assert_eq!(findings, 1);
+    }
+
     #[test]
     fn a_cell_with_no_header_is_scored_on_its_own() {
         let (row, seen, findings) = run_row(&[""], &["Madrid"], vec![vec![finding(0, 6)]]);
@@ -379,6 +422,8 @@ mod tests {
         assert_eq!(row, ["Madrid", "[REDACTED]"]);
     }
 
+    /// `DownloadModels::No`: the 1.16 GB model is placed in the cache by hand for these tests
+    /// and must never be fetched over the network by a test run.
     async fn redacter<'a>(reporter: &'a AppReporter<'a>) -> LocalGlinerRedacter<'a> {
         let options = ModelStoreOptions {
             download: DownloadModels::No,
@@ -473,6 +518,61 @@ mod tests {
         }
         assert!(out.contains("Apple Watch"), "{out}");
         assert!(out.contains("The Support Desk"), "{out}");
+    }
+
+    /// The `phone` column holds only digits and punctuation, so it exercises the digit-only
+    /// cell path directly against the model rather than a fake scorer.
+    #[tokio::test]
+    #[cfg_attr(not(feature = "ci-local-gliner"), ignore)]
+    async fn redacts_phone_numbers_in_the_customers_csv_fixture() {
+        let term = Term::stdout();
+        let reporter = AppReporter::from(&term);
+        let redacter = redacter(&reporter).await;
+        let fixture_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test-fixtures/documents/customers.csv"
+        );
+        let text = std::fs::read_to_string(fixture_path)
+            .unwrap_or_else(|err| panic!("read {fixture_path}: {err}"));
+        let mut lines = text.lines();
+        let headers: Vec<String> = lines
+            .next()
+            .unwrap_or_else(|| panic!("{fixture_path} has no header row"))
+            .split(',')
+            .map(str::to_string)
+            .collect();
+        let rows: Vec<Vec<String>> = lines
+            .map(|line| line.split(',').map(str::to_string).collect())
+            .collect();
+        assert_eq!(rows.len(), 3, "fixture changed: {fixture_path}");
+        let redacted = redacter
+            .redact(item(
+                "customers.csv",
+                mime::TEXT_CSV,
+                RedacterDataItemContent::Table { headers, rows },
+            ))
+            .await
+            .unwrap();
+        let RedacterDataItemContent::Table { headers, rows } = redacted.content else {
+            panic!("table stays table");
+        };
+        assert_eq!(
+            headers,
+            vec!["id", "full_name", "email", "phone", "city", "notes"]
+        );
+        assert_eq!(rows.len(), 3);
+        for phone in ["+1 (555) 123-4567", "+34 612 345 678", "+81 90-1234-5678"] {
+            assert!(
+                rows.iter().flatten().all(|cell| !cell.contains(phone)),
+                "{phone} survived: {rows:?}"
+            );
+        }
+        for city in ["London", "Madrid", "Osaka"] {
+            assert!(
+                rows.iter().flatten().any(|cell| cell.contains(city)),
+                "{city} missing: {rows:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/redacters/local_gliner/mod.rs
+++ b/src/redacters/local_gliner/mod.rs
@@ -443,11 +443,11 @@ mod tests {
         let term = Term::stdout();
         let reporter = AppReporter::from(&term);
         let redacter = redacter(&reporter).await;
-        let fixture_path = format!(
-            "{}/.claude/plans/2026-09-08-local-llm-spike-archive/experiments/spike-fixtures/contextual-en.txt",
-            std::env::var("HOME").expect("HOME is set")
+        let fixture_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test-fixtures/documents/contextual-en.txt"
         );
-        let text = std::fs::read_to_string(&fixture_path)
+        let text = std::fs::read_to_string(fixture_path)
             .unwrap_or_else(|err| panic!("read {fixture_path}: {err}"));
         let redacted = redacter
             .redact(item(

--- a/src/redacters/local_gliner/pipeline.rs
+++ b/src/redacters/local_gliner/pipeline.rs
@@ -1,0 +1,736 @@
+//! Pure windowing and span-decoding logic for the local GLiNER redacter: no model and no
+//! tokenizer types, so every rule is tested with hand-built token ids and fake logits.
+
+use super::error::LocalGlinerError;
+use crate::redacters::text_spans::{Finding, RuleName};
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// What the redacter looks for and how sure the model must be about a span.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlinerOptions {
+    pub labels: Vec<String>,
+    pub min_score: f32,
+}
+
+/// A whitespace-split word: GLiNER's `WhitespaceTokenSplitter`
+/// (`gliner/data_processing/tokenizer.py`) matches `\w+(?:[-_]\w+)*|\S`, i.e. runs of word
+/// characters optionally hyphen/underscore-joined, or any single other non-space character, so
+/// punctuation becomes its own word. Byte offsets, not character offsets, are what redaction
+/// needs to slice the original text.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Word<'a> {
+    pub text: &'a str,
+    pub start: usize,
+    pub end: usize,
+}
+
+fn word_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| Regex::new(r"\w+(?:[-_]\w+)*|\S").expect("static pattern is valid"))
+}
+
+pub fn split_words(text: &str) -> Vec<Word<'_>> {
+    word_pattern()
+        .find_iter(text)
+        .map(|m| Word {
+            text: m.as_str(),
+            start: m.start(),
+            end: m.end(),
+        })
+        .collect()
+}
+
+/// Tokens shared by two neighbouring windows, in words. Long documents cross a window
+/// boundary; a word near that boundary is scored from whichever window gives it more
+/// context on both sides, the same idea as the token overlap in `local_ner`.
+pub const OVERLAP_WORDS: usize = 32;
+
+/// A window over word indices: the model sees `start..end`; only `keep_from..keep_to` is
+/// taken from this window, the rest from the neighbour that has more context for it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WordWindow {
+    pub start: usize,
+    pub end: usize,
+    pub keep_from: usize,
+    pub keep_to: usize,
+}
+
+/// The token budget left for text words in one forward pass: `max_len` minus `[CLS]`/`[SEP]`
+/// minus the longest label-batch prompt, so every batch's window fits under `max_len` even
+/// though batches share the same window plan.
+pub fn window_budget(max_len: usize, prompt_lens: &[usize]) -> Result<usize, LocalGlinerError> {
+    let longest_prompt = prompt_lens.iter().copied().max().unwrap_or(0);
+    let frame = 2 + longest_prompt;
+    max_len
+        .checked_sub(frame)
+        .filter(|budget| *budget > 0)
+        .ok_or(LocalGlinerError::PromptTooLong {
+            prompt_tokens: longest_prompt,
+            max_len,
+        })
+}
+
+/// Cuts `word_token_counts.len()` words into windows whose subtoken budget never exceeds
+/// `budget`, overlapping by roughly `overlap` words. A single word wider than `budget` still
+/// gets its own window rather than being split or dropped. The keep ranges tile every word
+/// exactly once, splitting each overlap near the middle.
+pub fn plan_word_windows(
+    word_token_counts: &[usize],
+    budget: usize,
+    overlap: usize,
+) -> Vec<WordWindow> {
+    let n = word_token_counts.len();
+    if n == 0 || budget == 0 {
+        return Vec::new();
+    }
+    // Pass 1: greedily pack words into windows of at most `budget` tokens, each starting
+    // `overlap` words before the previous window's end. Always take at least one word, even
+    // if it alone exceeds the budget, so a single oversized word gets its own window rather
+    // than stalling the loop.
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    let mut start = 0usize;
+    loop {
+        let mut end = start + 1;
+        let mut used = word_token_counts[start];
+        while end < n {
+            let next = word_token_counts[end];
+            if used + next > budget {
+                break;
+            }
+            used += next;
+            end += 1;
+        }
+        spans.push((start, end));
+        if end == n {
+            break;
+        }
+        let stride = (end - start).saturating_sub(overlap).max(1);
+        start += stride;
+    }
+    // Pass 2: split each shared region between neighbours at its midpoint. Two adjacent
+    // windows compute the same split point from their shared boundary, so the keep ranges
+    // tile `0..n` exactly once regardless of how uneven the window sizes are; a pair of
+    // windows with no shared region (an oversized word left no room for overlap) still
+    // splits at their touching boundary, so neither drops a word.
+    let mut windows = Vec::with_capacity(spans.len());
+    for (i, &(start, end)) in spans.iter().enumerate() {
+        let keep_from = if i == 0 {
+            0
+        } else {
+            let prev_end = spans[i - 1].1;
+            start + prev_end.saturating_sub(start) / 2
+        };
+        let keep_to = if i + 1 == spans.len() {
+            n
+        } else {
+            let next_start = spans[i + 1].0;
+            next_start + end.saturating_sub(next_start) / 2
+        };
+        windows.push(WordWindow {
+            start,
+            end,
+            keep_from,
+            keep_to,
+        });
+    }
+    windows
+}
+
+/// All possible `(start_word, end_word)` pairs for `num_words` words and the model's
+/// `max_width`, inclusive on both ends, in the row-major `[word][width]` order the graph's
+/// `span_idx` input expects (`gliner/data_processing/utils.py::prepare_span_idx`).
+pub fn span_candidates(num_words: usize, max_width: usize) -> Vec<[i32; 2]> {
+    let mut spans = Vec::with_capacity(num_words * max_width);
+    for start in 0..num_words {
+        for width in 0..max_width {
+            spans.push([start as i32, (start + width) as i32]);
+        }
+    }
+    spans
+}
+
+/// Builds the prompt token sequence `<<ENT>> label_1 ... <<ENT>> label_L <<SEP>>` for one
+/// label batch, without `[CLS]`/`[SEP]`: those frame the whole window.
+pub fn prompt_ids(ent: u32, gliner_sep: u32, label_ids: &[Vec<u32>]) -> Vec<u32> {
+    let mut ids = Vec::new();
+    for label in label_ids {
+        ids.push(ent);
+        ids.extend_from_slice(label);
+    }
+    ids.push(gliner_sep);
+    ids
+}
+
+/// One forward pass worth of tensors, already shaped `[1, ...]` (batch size 1).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WindowInputs {
+    /// Token ids: `[CLS] prompt... word_subtokens... [SEP]`.
+    pub ids: Vec<i32>,
+    /// Same length as `ids`; 0 everywhere except the first subtoken of each text word, which
+    /// carries that word's 1-based index within this window.
+    pub words_mask: Vec<i32>,
+    /// Number of text words in this window (`span_idx` end positions are checked against it).
+    pub num_words: usize,
+    /// `(start_word, end_word)` pairs, inclusive, in row-major `[word][width]` order.
+    pub span_idx: Vec<[i32; 2]>,
+    /// 1 where the span's end word is within `num_words`, 0 otherwise (padding candidates).
+    pub span_mask: Vec<i32>,
+}
+
+/// Assembles one window's token/mask/span tensors from already-tokenized words and prompt.
+pub fn window_inputs(
+    cls: u32,
+    sep: u32,
+    prompt: &[u32],
+    word_ids: &[&[u32]],
+    max_width: usize,
+) -> WindowInputs {
+    let num_words = word_ids.len();
+    let mut ids = Vec::with_capacity(1 + prompt.len() + num_words * 2 + 1);
+    let mut words_mask = Vec::with_capacity(ids.capacity());
+
+    ids.push(cls as i32);
+    words_mask.push(0);
+    for &id in prompt {
+        ids.push(id as i32);
+        words_mask.push(0);
+    }
+    for (word_index, subtokens) in word_ids.iter().enumerate() {
+        for (sub_index, &id) in subtokens.iter().enumerate() {
+            ids.push(id as i32);
+            words_mask.push(if sub_index == 0 {
+                (word_index + 1) as i32
+            } else {
+                0
+            });
+        }
+    }
+    ids.push(sep as i32);
+    words_mask.push(0);
+
+    let span_idx = span_candidates(num_words, max_width);
+    let span_mask = span_idx
+        .iter()
+        .map(|[_, end]| i32::from((*end as usize) < num_words))
+        .collect();
+
+    WindowInputs {
+        ids,
+        words_mask,
+        num_words,
+        span_idx,
+        span_mask,
+    }
+}
+
+/// `logits[word][width][label]`, already flattened; call sites index with the strides this
+/// struct exposes rather than reshaping, since only one window is scored per call.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Logits {
+    pub num_words: usize,
+    pub max_width: usize,
+    pub num_labels: usize,
+    pub data: Vec<f32>,
+}
+
+impl Logits {
+    pub fn at(&self, word: usize, width: usize, label: usize) -> f32 {
+        let idx = (word * self.max_width + width) * self.num_labels + label;
+        self.data[idx]
+    }
+}
+
+/// Scores one window of already-built tensors against `num_labels` labels.
+pub trait WindowScorer {
+    fn score_window(
+        &self,
+        inputs: &WindowInputs,
+        num_labels: usize,
+    ) -> Result<Logits, LocalGlinerError>;
+}
+
+fn sigmoid(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+/// One candidate entity span, in both word and byte coordinates. Byte coordinates are what
+/// redaction needs; word coordinates are what non-overlap decoding needs, since two spans
+/// can share a boundary byte only when they share no word.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Candidate {
+    pub start_word: usize,
+    pub end_word: usize,
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub label: String,
+    pub score: f32,
+}
+
+fn collect_candidates(
+    logits: &Logits,
+    window_words: &[Word],
+    word_offset: usize,
+    labels: &[String],
+    threshold: f32,
+    out: &mut Vec<Candidate>,
+) {
+    for start in 0..logits.num_words {
+        for width in 0..logits.max_width {
+            let end = start + width;
+            if end >= logits.num_words {
+                continue;
+            }
+            for (label_index, label) in labels.iter().enumerate() {
+                let score = sigmoid(logits.at(start, width, label_index));
+                if score >= threshold {
+                    out.push(Candidate {
+                        start_word: word_offset + start,
+                        end_word: word_offset + end,
+                        start_byte: window_words[start].start,
+                        end_byte: window_words[end].end,
+                        label: label.clone(),
+                        score,
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Scores every window of `words` against every label batch and returns every candidate span
+/// at or above `threshold`, unresolved (overlapping candidates from different labels or
+/// batches are expected; [`greedy_decode`] resolves them). Every batch shares one window
+/// plan, built from the tightest budget across batches, so a word is scored at the same
+/// window position for every label.
+#[allow(clippy::too_many_arguments)]
+pub fn score_document(
+    scorer: &dyn WindowScorer,
+    cls: u32,
+    sep: u32,
+    ent: u32,
+    gliner_sep: u32,
+    words: &[Word],
+    word_ids: &[Vec<u32>],
+    label_batches: &[&[String]],
+    label_ids: &[Vec<Vec<u32>>],
+    max_len: usize,
+    max_width: usize,
+    overlap: usize,
+    threshold: f32,
+) -> Result<Vec<Candidate>, LocalGlinerError> {
+    if words.is_empty() {
+        return Ok(Vec::new());
+    }
+    let prompts: Vec<Vec<u32>> = label_ids
+        .iter()
+        .map(|ids| prompt_ids(ent, gliner_sep, ids))
+        .collect();
+    let prompt_lens: Vec<usize> = prompts.iter().map(Vec::len).collect();
+    let budget = window_budget(max_len, &prompt_lens)?;
+
+    let word_token_counts: Vec<usize> = word_ids.iter().map(Vec::len).collect();
+    let windows = plan_word_windows(&word_token_counts, budget, overlap);
+
+    let mut candidates = Vec::new();
+    for (batch_index, labels) in label_batches.iter().enumerate() {
+        let prompt = &prompts[batch_index];
+        for window in &windows {
+            let window_word_ids: Vec<&[u32]> = word_ids[window.start..window.end]
+                .iter()
+                .map(Vec::as_slice)
+                .collect();
+            let inputs = window_inputs(cls, sep, prompt, &window_word_ids, max_width);
+            let logits = scorer.score_window(&inputs, labels.len())?;
+            let mut window_candidates = Vec::new();
+            collect_candidates(
+                &logits,
+                &words[window.start..window.end],
+                window.start,
+                labels,
+                threshold,
+                &mut window_candidates,
+            );
+            candidates.extend(
+                window_candidates
+                    .into_iter()
+                    .filter(|c| c.start_word >= window.keep_from && c.start_word < window.keep_to),
+            );
+        }
+    }
+    Ok(candidates)
+}
+
+/// Sorts candidates by descending score and keeps each one whose word range does not
+/// overlap a previously accepted span, highest-confidence spans winning ties for a word.
+/// Returned in document order.
+pub fn greedy_decode(mut candidates: Vec<Candidate>) -> Vec<Candidate> {
+    candidates.sort_by(|a, b| b.score.total_cmp(&a.score));
+    let mut accepted: Vec<Candidate> = Vec::new();
+    for candidate in candidates {
+        let overlaps = accepted.iter().any(|kept| {
+            candidate.start_word <= kept.end_word && kept.start_word <= candidate.end_word
+        });
+        if !overlaps {
+            accepted.push(candidate);
+        }
+    }
+    accepted.sort_by_key(|c| c.start_byte);
+    accepted
+}
+
+/// Maps accepted, non-overlapping candidates to byte-range findings named by their label.
+pub fn candidates_to_findings(candidates: Vec<Candidate>) -> Vec<Finding> {
+    candidates
+        .into_iter()
+        .map(|candidate| Finding {
+            start: candidate.start_byte,
+            end: candidate.end_byte,
+            rule: RuleName::new(&candidate.label),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    #[test]
+    fn splits_on_whitespace_and_keeps_hyphenated_words_together() {
+        let words = split_words("Jean-Paul lives in São Paulo.");
+        let texts: Vec<&str> = words.iter().map(|w| w.text).collect();
+        assert_eq!(texts, vec!["Jean-Paul", "lives", "in", "São", "Paulo", "."]);
+    }
+
+    #[test]
+    fn punctuation_becomes_its_own_word() {
+        let words = split_words("a, b!");
+        let texts: Vec<&str> = words.iter().map(|w| w.text).collect();
+        assert_eq!(texts, vec!["a", ",", "b", "!"]);
+    }
+
+    #[test]
+    fn offsets_are_byte_offsets_that_round_trip() {
+        let text = "call 555-1234 now, José";
+        for word in split_words(text) {
+            assert_eq!(&text[word.start..word.end], word.text);
+        }
+    }
+
+    #[test]
+    fn empty_text_has_no_words() {
+        assert!(split_words("").is_empty());
+        assert!(split_words("   ").is_empty());
+    }
+
+    #[test]
+    fn window_budget_is_max_len_minus_special_tokens_and_the_longest_prompt() {
+        assert_eq!(window_budget(384, &[10, 25, 5]).unwrap(), 384 - 2 - 25);
+        assert_eq!(window_budget(20, &[0]).unwrap(), 18);
+    }
+
+    #[test]
+    fn window_budget_rejects_a_prompt_that_leaves_no_room() {
+        let err = window_budget(10, &[9]).unwrap_err();
+        assert!(
+            matches!(err, LocalGlinerError::PromptTooLong { .. }),
+            "{err}"
+        );
+        let err = window_budget(10, &[8]).unwrap_err();
+        assert!(
+            matches!(err, LocalGlinerError::PromptTooLong { .. }),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn plan_word_windows_edge_cases() {
+        assert!(plan_word_windows(&[], 10, 4).is_empty());
+        assert_eq!(
+            plan_word_windows(&[3], 10, 4),
+            vec![WordWindow {
+                start: 0,
+                end: 1,
+                keep_from: 0,
+                keep_to: 1
+            }]
+        );
+        // Every word fits in one window.
+        assert_eq!(
+            plan_word_windows(&[1, 1, 1, 1, 1], 10, 4),
+            vec![WordWindow {
+                start: 0,
+                end: 5,
+                keep_from: 0,
+                keep_to: 5
+            }]
+        );
+    }
+
+    #[test]
+    fn plan_word_windows_keep_ranges_tile_every_word_once() {
+        for n in [0usize, 1, 9, 10, 11, 13, 25, 100, 500] {
+            let counts = vec![1usize; n];
+            let covered: Vec<usize> = plan_word_windows(&counts, 10, 4)
+                .iter()
+                .flat_map(|w| w.keep_from..w.keep_to)
+                .collect();
+            assert_eq!(covered, (0..n).collect::<Vec<_>>(), "n = {n}");
+        }
+    }
+
+    #[test]
+    fn plan_word_windows_gives_an_oversized_word_its_own_window() {
+        let windows = plan_word_windows(&[1, 20, 1], 5, 2);
+        let covered: Vec<usize> = windows
+            .iter()
+            .flat_map(|w| w.keep_from..w.keep_to)
+            .collect();
+        assert_eq!(covered, vec![0, 1, 2]);
+        assert!(
+            windows.iter().any(|w| w.start == 1 && w.end == 2),
+            "{windows:?}"
+        );
+    }
+
+    #[test]
+    fn span_candidates_cover_every_word_and_width_in_row_major_order() {
+        let spans = span_candidates(3, 2);
+        assert_eq!(spans, vec![[0, 0], [0, 1], [1, 1], [1, 2], [2, 2], [2, 3]]);
+    }
+
+    #[test]
+    fn prompt_ids_frames_each_label_with_ent_and_ends_with_gliner_sep() {
+        let ids = prompt_ids(100, 200, &[vec![1, 2], vec![3]]);
+        assert_eq!(ids, vec![100, 1, 2, 100, 3, 200]);
+    }
+
+    #[test]
+    fn window_inputs_builds_ids_words_mask_and_span_tensors() {
+        let word_ids: Vec<&[u32]> = vec![&[10, 11], &[12]];
+        let inputs = window_inputs(1, 2, &[50, 51], &word_ids, 2);
+        assert_eq!(inputs.ids, vec![1, 50, 51, 10, 11, 12, 2]);
+        assert_eq!(inputs.words_mask, vec![0, 0, 0, 1, 0, 2, 0]);
+        assert_eq!(inputs.num_words, 2);
+        assert_eq!(inputs.span_idx, vec![[0, 0], [0, 1], [1, 1], [1, 2]]);
+        assert_eq!(inputs.span_mask, vec![1, 1, 1, 0]);
+    }
+
+    #[test]
+    fn logits_at_indexes_the_flattened_word_width_label_layout() {
+        let logits = Logits {
+            num_words: 2,
+            max_width: 3,
+            num_labels: 2,
+            data: (0..12).map(|v| v as f32).collect(),
+        };
+        assert_eq!(logits.at(0, 0, 0), 0.0);
+        assert_eq!(logits.at(0, 0, 1), 1.0);
+        assert_eq!(logits.at(1, 2, 1), 11.0);
+    }
+
+    struct FakeScorer {
+        /// `(start_word, end_word, label_index) -> logit`; anything else scores far below 0.
+        hits: Vec<(usize, usize, usize, f32)>,
+        calls: RefCell<Vec<WindowInputs>>,
+    }
+
+    impl WindowScorer for FakeScorer {
+        fn score_window(
+            &self,
+            inputs: &WindowInputs,
+            num_labels: usize,
+        ) -> Result<Logits, LocalGlinerError> {
+            self.calls.borrow_mut().push(inputs.clone());
+            let max_width = 12;
+            let mut data = vec![-10.0f32; inputs.num_words * max_width * num_labels];
+            for &(start, end, label, logit) in &self.hits {
+                if start < inputs.num_words {
+                    let width = end - start;
+                    if width < max_width {
+                        let idx = (start * max_width + width) * num_labels + label;
+                        if idx < data.len() {
+                            data[idx] = logit;
+                        }
+                    }
+                }
+            }
+            Ok(Logits {
+                num_words: inputs.num_words,
+                max_width,
+                num_labels,
+                data,
+            })
+        }
+    }
+
+    fn word(text: &'static str, start: usize, end: usize) -> Word<'static> {
+        Word { text, start, end }
+    }
+
+    #[test]
+    fn score_document_finds_a_span_above_threshold_and_ignores_one_below() {
+        let words = vec![word("Alice", 0, 5), word("called", 6, 12)];
+        let word_ids = vec![vec![10u32], vec![11u32]];
+        let labels = vec!["person".to_string()];
+        let label_batches: Vec<&[String]> = vec![&labels];
+        let label_ids = vec![vec![vec![99u32]]];
+        let scorer = FakeScorer {
+            // "Alice" (word 0, width 0) scores high for label 0; "called" scores low.
+            hits: vec![(0, 0, 0, 10.0), (1, 1, 0, -10.0)],
+            calls: RefCell::new(Vec::new()),
+        };
+        let candidates = score_document(
+            &scorer,
+            1,
+            2,
+            100,
+            200,
+            &words,
+            &word_ids,
+            &label_batches,
+            &label_ids,
+            384,
+            12,
+            32,
+            0.5,
+        )
+        .unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].start_byte, 0);
+        assert_eq!(candidates[0].end_byte, 5);
+        assert_eq!(candidates[0].label, "person");
+        assert!(candidates[0].score > 0.99, "{}", candidates[0].score);
+    }
+
+    fn candidate(
+        start_word: usize,
+        end_word: usize,
+        start_byte: usize,
+        end_byte: usize,
+        score: f32,
+    ) -> Candidate {
+        Candidate {
+            start_word,
+            end_word,
+            start_byte,
+            end_byte,
+            label: "x".to_string(),
+            score,
+        }
+    }
+
+    #[test]
+    fn greedy_decode_drops_a_lower_score_overlap() {
+        let candidates = vec![candidate(0, 2, 0, 10, 0.6), candidate(1, 1, 4, 6, 0.9)];
+        let accepted = greedy_decode(candidates);
+        assert_eq!(accepted.len(), 1);
+        assert_eq!((accepted[0].start_byte, accepted[0].end_byte), (4, 6));
+    }
+
+    #[test]
+    fn greedy_decode_keeps_non_overlapping_spans_in_document_order() {
+        let candidates = vec![candidate(1, 1, 5, 9, 0.5), candidate(0, 0, 0, 4, 0.5)];
+        let accepted = greedy_decode(candidates);
+        assert_eq!(accepted.len(), 2);
+        assert_eq!(accepted[0].start_byte, 0);
+        assert_eq!(accepted[1].start_byte, 5);
+    }
+
+    #[test]
+    fn candidates_to_findings_names_the_rule_after_the_label() {
+        let findings = candidates_to_findings(vec![candidate(0, 0, 0, 5, 0.9)]);
+        assert_eq!(
+            findings,
+            vec![Finding {
+                start: 0,
+                end: 5,
+                rule: RuleName::new("x")
+            }]
+        );
+    }
+
+    /// Scores whichever local word carries `sentinel_id`, wherever a window places it; this
+    /// is what lets the boundary test below assert on a global word index without knowing in
+    /// advance which window keeps it.
+    struct SentinelScorer {
+        sentinel_id: i32,
+        calls: RefCell<usize>,
+    }
+
+    impl WindowScorer for SentinelScorer {
+        fn score_window(
+            &self,
+            inputs: &WindowInputs,
+            num_labels: usize,
+        ) -> Result<Logits, LocalGlinerError> {
+            *self.calls.borrow_mut() += 1;
+            let max_width = 12;
+            let mut data = vec![-10.0f32; inputs.num_words * max_width * num_labels];
+            if let Some(position) = inputs.ids.iter().position(|&id| id == self.sentinel_id) {
+                let local_word = inputs.words_mask[position] - 1;
+                if local_word >= 0 {
+                    let idx = (local_word as usize * max_width) * num_labels;
+                    data[idx] = 10.0;
+                }
+            }
+            Ok(Logits {
+                num_words: inputs.num_words,
+                max_width,
+                num_labels,
+                data,
+            })
+        }
+    }
+
+    #[test]
+    fn a_span_crossing_a_window_boundary_is_still_found_once() {
+        // 40 one-token words, a small per-window budget forces several windows; word 20
+        // carries a sentinel token id so the assertion holds regardless of which window's
+        // keep range ends up covering it.
+        let mut text = String::new();
+        let mut words: Vec<Word> = Vec::new();
+        for i in 0..40 {
+            let start = text.len();
+            let w = format!("w{i}");
+            text.push_str(&w);
+            text.push(' ');
+            words.push(Word {
+                text: Box::leak(w.into_boxed_str()),
+                start,
+                end: start + text[start..].trim_end().len(),
+            });
+        }
+        let word_ids: Vec<Vec<u32>> = (0..40u32)
+            .map(|i| vec![if i == 20 { 9000 } else { i }])
+            .collect();
+        let labels = vec!["thing".to_string()];
+        let label_batches: Vec<&[String]> = vec![&labels];
+        let label_ids = vec![vec![vec![999u32]]];
+        let scorer = SentinelScorer {
+            sentinel_id: 9000,
+            calls: RefCell::new(0),
+        };
+        let candidates = score_document(
+            &scorer,
+            1,
+            2,
+            100,
+            200,
+            &words,
+            &word_ids,
+            &label_batches,
+            &label_ids,
+            14,
+            12,
+            4,
+            0.5,
+        )
+        .unwrap();
+        assert_eq!(candidates.len(), 1, "{candidates:?}");
+        assert_eq!(candidates[0].start_word, 20);
+        assert_eq!(candidates[0].end_word, 20);
+        assert!(*scorer.calls.borrow() > 1, "expected several windows");
+    }
+}

--- a/src/redacters/local_gliner/pipeline.rs
+++ b/src/redacters/local_gliner/pipeline.rs
@@ -57,8 +57,11 @@ pub struct WordWindow {
 }
 
 /// The token budget left for text words in one forward pass: `max_len` minus `[CLS]`/`[SEP]`
-/// minus the longest label-batch prompt, so every batch's window fits under `max_len` even
-/// though batches share the same window plan.
+/// minus the longest label-batch prompt. This bounds how many word tokens a window plan may
+/// pack in, not how many a single word may contribute: `plan_word_windows` gives a word wider
+/// than this budget its own window rather than splitting or dropping it, and `window_inputs`
+/// truncates that word's subtokens to the budget when building the window's tensors, so every
+/// window's token count fits under `max_len` regardless of how long any one word tokenizes to.
 pub fn window_budget(max_len: usize, prompt_lens: &[usize]) -> Result<usize, LocalGlinerError> {
     let longest_prompt = prompt_lens.iter().copied().max().unwrap_or(0);
     let frame = 2 + longest_prompt;
@@ -179,12 +182,18 @@ pub struct WindowInputs {
 }
 
 /// Assembles one window's token/mask/span tensors from already-tokenized words and prompt.
+/// `budget` is the text-word token budget from [`window_budget`]: a word whose own subtoken
+/// count alone exceeds it (`plan_word_windows` still gives such a word its own window rather
+/// than splitting or dropping it) has its subtokens truncated to fit, so the graph never sees
+/// more than `budget` word tokens. The word still occupies exactly one span-decoding slot, so
+/// a span tagged on it redacts the whole word even though only a token prefix reached the model.
 pub fn window_inputs(
     cls: u32,
     sep: u32,
     prompt: &[u32],
     word_ids: &[&[u32]],
     max_width: usize,
+    budget: usize,
 ) -> WindowInputs {
     let num_words = word_ids.len();
     let mut ids = Vec::with_capacity(1 + prompt.len() + num_words * 2 + 1);
@@ -196,8 +205,11 @@ pub fn window_inputs(
         ids.push(id as i32);
         words_mask.push(0);
     }
+    let mut remaining = budget;
     for (word_index, subtokens) in word_ids.iter().enumerate() {
-        for (sub_index, &id) in subtokens.iter().enumerate() {
+        let take = subtokens.len().min(remaining);
+        remaining -= take;
+        for (sub_index, &id) in subtokens[..take].iter().enumerate() {
             ids.push(id as i32);
             words_mask.push(if sub_index == 0 {
                 (word_index + 1) as i32
@@ -340,7 +352,7 @@ pub fn score_document(
                 .iter()
                 .map(Vec::as_slice)
                 .collect();
-            let inputs = window_inputs(cls, sep, prompt, &window_word_ids, max_width);
+            let inputs = window_inputs(cls, sep, prompt, &window_word_ids, max_width, budget);
             let logits = scorer.score_window(&inputs, labels.len())?;
             let mut window_candidates = Vec::new();
             collect_candidates(
@@ -509,12 +521,28 @@ mod tests {
     #[test]
     fn window_inputs_builds_ids_words_mask_and_span_tensors() {
         let word_ids: Vec<&[u32]> = vec![&[10, 11], &[12]];
-        let inputs = window_inputs(1, 2, &[50, 51], &word_ids, 2);
+        let inputs = window_inputs(1, 2, &[50, 51], &word_ids, 2, 3);
         assert_eq!(inputs.ids, vec![1, 50, 51, 10, 11, 12, 2]);
         assert_eq!(inputs.words_mask, vec![0, 0, 0, 1, 0, 2, 0]);
         assert_eq!(inputs.num_words, 2);
         assert_eq!(inputs.span_idx, vec![[0, 0], [0, 1], [1, 1], [1, 2]]);
         assert_eq!(inputs.span_mask, vec![1, 1, 1, 0]);
+    }
+
+    /// A single word whose own subtoken count exceeds the budget still gets a window (per
+    /// `plan_word_windows`), so `window_inputs` must cap what it feeds the graph itself.
+    #[test]
+    fn window_inputs_truncates_a_word_that_alone_exceeds_the_budget() {
+        let oversized: Vec<u32> = (100..110).collect(); // 10 subtokens, budget is 4.
+        let word_ids: Vec<&[u32]> = vec![&oversized];
+        let inputs = window_inputs(1, 2, &[50], &word_ids, 12, 4);
+        // [CLS] + prompt(1) + at most 4 word subtokens + [SEP] = 7.
+        assert_eq!(inputs.ids.len(), 7, "{inputs:?}");
+        assert_eq!(inputs.ids, vec![1, 50, 100, 101, 102, 103, 2]);
+        // The word still keeps its own word index and counts as one word for span decoding,
+        // so a tagged word is redacted in full even though only its prefix reached the model.
+        assert_eq!(inputs.words_mask, vec![0, 0, 1, 0, 0, 0, 0]);
+        assert_eq!(inputs.num_words, 1);
     }
 
     #[test]
@@ -732,5 +760,82 @@ mod tests {
         assert_eq!(candidates[0].start_word, 20);
         assert_eq!(candidates[0].end_word, 20);
         assert!(*scorer.calls.borrow() > 1, "expected several windows");
+    }
+
+    /// Scores a window's single word as a hit whenever its ids carry one of two sentinels,
+    /// so a hit on the oversized word (whose real subtoken ids are truncated away) is
+    /// impossible; only the two short neighbour words can ever be scored.
+    struct TwoSentinelScorer {
+        calls: RefCell<Vec<WindowInputs>>,
+    }
+
+    impl WindowScorer for TwoSentinelScorer {
+        fn score_window(
+            &self,
+            inputs: &WindowInputs,
+            num_labels: usize,
+        ) -> Result<Logits, LocalGlinerError> {
+            self.calls.borrow_mut().push(inputs.clone());
+            let max_width = 12;
+            let mut data = vec![-10.0f32; inputs.num_words * max_width * num_labels];
+            if inputs.ids.contains(&11) || inputs.ids.contains(&33) {
+                data[0] = 10.0;
+            }
+            Ok(Logits {
+                num_words: inputs.num_words,
+                max_width,
+                num_labels,
+                data,
+            })
+        }
+    }
+
+    #[test]
+    fn score_document_caps_an_oversized_word_at_the_budget_and_still_scores_its_neighbours() {
+        let words = vec![
+            word("Alice", 0, 5),
+            word("XXXXXXXXXXXXXXXXXXXX", 6, 26),
+            word("Bob", 27, 30),
+        ];
+        let word_ids: Vec<Vec<u32>> = vec![vec![11u32], (900..920).collect(), vec![33u32]];
+        let labels = vec!["person".to_string()];
+        let label_batches: Vec<&[String]> = vec![&labels];
+        let label_ids = vec![vec![vec![99u32]]];
+        let scorer = TwoSentinelScorer {
+            calls: RefCell::new(Vec::new()),
+        };
+        let max_len = 10;
+        let candidates = score_document(
+            &scorer,
+            1,
+            2,
+            100,
+            200,
+            &words,
+            &word_ids,
+            &label_batches,
+            &label_ids,
+            max_len,
+            12,
+            0,
+            0.5,
+        )
+        .unwrap();
+
+        let calls = scorer.calls.borrow();
+        assert!(
+            calls.iter().all(|c| c.ids.len() <= max_len),
+            "a window exceeded max_len: {calls:?}"
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.num_words == 1 && c.ids.len() == max_len),
+            "expected the oversized word's window packed to the full budget: {calls:?}"
+        );
+
+        assert_eq!(candidates.len(), 2, "{candidates:?}");
+        assert_eq!((candidates[0].start_byte, candidates[0].end_byte), (0, 5));
+        assert_eq!((candidates[1].start_byte, candidates[1].end_byte), (27, 30));
     }
 }

--- a/src/redacters/mod.rs
+++ b/src/redacters/mod.rs
@@ -39,7 +39,12 @@ pub(crate) mod local_ner;
 #[cfg(feature = "local-ner")]
 pub use local_ner::{Entity, LocalNerRedacter, LocalNerRedacterOptions};
 
-/// Byte-span helpers shared by the local redacters (`local-rules`, `local-ner`).
+#[cfg(feature = "local-gliner")]
+pub(crate) mod local_gliner;
+#[cfg(feature = "local-gliner")]
+pub use local_gliner::{LocalGlinerRedacter, LocalGlinerRedacterOptions};
+
+/// Byte-span helpers shared by the local redacters (`local-rules`, `local-ner`, `local-gliner`).
 pub(crate) mod text_spans;
 
 mod open_ai_llm;
@@ -353,6 +358,8 @@ pub enum Redacters<'a> {
     LocalRules(LocalRulesRedacter<'a>),
     #[cfg(feature = "local-ner")]
     LocalNer(LocalNerRedacter<'a>),
+    #[cfg(feature = "local-gliner")]
+    LocalGliner(LocalGlinerRedacter<'a>),
 }
 
 #[derive(Debug, Clone)]
@@ -383,6 +390,8 @@ pub enum RedacterProviderOptions {
     LocalRules(LocalRulesRedacterOptions),
     #[cfg(feature = "local-ner")]
     LocalNer(LocalNerRedacterOptions),
+    #[cfg(feature = "local-gliner")]
+    LocalGliner(LocalGlinerRedacterOptions),
 }
 
 impl RedacterProviderOptions {
@@ -400,6 +409,8 @@ impl RedacterProviderOptions {
             RedacterProviderOptions::LocalRules(_) => RedacterType::LocalRules,
             #[cfg(feature = "local-ner")]
             RedacterProviderOptions::LocalNer(_) => RedacterType::LocalNer,
+            #[cfg(feature = "local-gliner")]
+            RedacterProviderOptions::LocalGliner(_) => RedacterType::LocalGliner,
         }
     }
 
@@ -409,6 +420,10 @@ impl RedacterProviderOptions {
         #[cfg(feature = "local-ner")]
         if let RedacterProviderOptions::LocalNer(_) = self {
             return vec![ModelId::NerMultilingualHrl];
+        }
+        #[cfg(feature = "local-gliner")]
+        if let RedacterProviderOptions::LocalGliner(_) = self {
+            return vec![ModelId::GlinerMultiPii];
         }
         Vec::new()
     }
@@ -427,7 +442,10 @@ impl Display for RedacterOptions {
 }
 
 impl<'a> Redacters<'a> {
-    #[cfg_attr(not(feature = "local-ner"), allow(unused_variables))]
+    #[cfg_attr(
+        not(any(feature = "local-ner", feature = "local-gliner")),
+        allow(unused_variables)
+    )]
     pub async fn new_redacter(
         provider_options: RedacterProviderOptions,
         reporter: &'a AppReporter<'a>,
@@ -466,6 +484,10 @@ impl<'a> Redacters<'a> {
             #[cfg(feature = "local-ner")]
             RedacterProviderOptions::LocalNer(options) => Ok(Redacters::LocalNer(
                 LocalNerRedacter::new(options, reporter, models).await?,
+            )),
+            #[cfg(feature = "local-gliner")]
+            RedacterProviderOptions::LocalGliner(options) => Ok(Redacters::LocalGliner(
+                LocalGlinerRedacter::new(options, reporter, models).await?,
             )),
         }
     }
@@ -550,6 +572,8 @@ impl<'a> Redacter for Redacters<'a> {
             Redacters::LocalRules(redacter) => redacter.redact(input).await,
             #[cfg(feature = "local-ner")]
             Redacters::LocalNer(redacter) => redacter.redact(input).await,
+            #[cfg(feature = "local-gliner")]
+            Redacters::LocalGliner(redacter) => redacter.redact(input).await,
         }
     }
 
@@ -566,6 +590,8 @@ impl<'a> Redacter for Redacters<'a> {
             Redacters::LocalRules(redacter) => redacter.redact_support(file_ref).await,
             #[cfg(feature = "local-ner")]
             Redacters::LocalNer(redacter) => redacter.redact_support(file_ref).await,
+            #[cfg(feature = "local-gliner")]
+            Redacters::LocalGliner(redacter) => redacter.redact_support(file_ref).await,
         }
     }
 
@@ -582,6 +608,8 @@ impl<'a> Redacter for Redacters<'a> {
             Redacters::LocalRules(_) => RedacterType::LocalRules,
             #[cfg(feature = "local-ner")]
             Redacters::LocalNer(_) => RedacterType::LocalNer,
+            #[cfg(feature = "local-gliner")]
+            Redacters::LocalGliner(_) => RedacterType::LocalGliner,
         }
     }
 }

--- a/src/redacters/mod.rs
+++ b/src/redacters/mod.rs
@@ -631,7 +631,7 @@ pub mod test_support {
     /// information, that exercise a text, table, structured and PDF media type. The
     /// multilingual note is German, French and Spanish text for the local redacters.
     pub const TEST_DOCUMENTS_DIR: &str = "test-fixtures/documents/";
-    pub const TEST_DOCUMENT_NAMES: [&str; 8] = [
+    pub const TEST_DOCUMENT_NAMES: [&str; 9] = [
         "customer-note.txt",
         "customers.csv",
         "customer.json",
@@ -640,6 +640,7 @@ pub mod test_support {
         "multilingual.txt",
         "dates-en.txt",
         "false-positives-en.txt",
+        "contextual-en.txt",
     ];
     pub const TEST_DOCUMENT_SAMPLE_EMAIL: &str = "john.smith@example.com";
     pub const TEST_DOCUMENT_SAMPLE_PHONE: &str = "+1 (555) 123-4567";

--- a/test-fixtures/bench-dlp/README.md
+++ b/test-fixtures/bench-dlp/README.md
@@ -6,9 +6,9 @@ A small, fixed-corpus benchmark comparing the redacter CLI's providers on:
 - **detection quality**: does each provider actually remove the PII in the
   corpus, and does it leave non-PII "control" text alone?
 
-Providers compared: the offline ones (`local-rules`, `local-ner`, and the
-chain `local-rules+local-ner`) against the cloud ones (`gcp-dlp`,
-`gcp-vertex-ai`).
+Providers compared: the offline ones (`local-rules`, `local-ner`, `local-gliner`,
+and the chains `local-rules+local-ner` and `local-rules+local-gliner`) against
+the cloud ones (`gcp-dlp`, `gcp-vertex-ai`).
 
 Not part of the `redacter` crate build; this is a measurement harness kept
 under `test-fixtures/` for re-runs after future changes to the redacters, run
@@ -41,9 +41,13 @@ names, postal addresses or `entities` (it has no notion of named entities) --
 only structured PII like emails, phones, card numbers and IDs.  `local-ner` is
 a named-entity model: it is not expected to hit emails, phones, card numbers
 or IDs (it has no notion of those formats) -- only names and, depending on
-`--local-ner-entities`, organisations and locations. `local-rules+local-ner`
-(the chain, run left to right) is the intended production configuration: it
-is expected to cover both classes.
+`--local-ner-entities`, organisations and locations. `local-gliner` is a
+zero-shot span model driven by free-text labels (`--local-gliner-labels`):
+it is expected to cover both classes on its own, since its default label list
+includes both structured PII and person/address labels, but it has no notion
+of an entity type it was not given a label for. `local-rules+local-ner` and
+`local-rules+local-gliner` (each a chain, run left to right) are production
+configurations: they are expected to cover both classes.
 
 The same literal text can be PII in one file and a control in another on
 purpose -- e.g. `"14 March 1985"` is a customer's date of birth in
@@ -53,7 +57,7 @@ which is exactly the kind of gap this benchmark is meant to surface.
 
 ## Corpus
 
-Seven text-only fixtures (no images/PDF, to keep cloud cost and OCR variance
+Eight text-only fixtures (no images/PDF, to keep cloud cost and OCR variance
 out of the comparison), copied from `test-fixtures/documents/` into a fresh
 temp directory by name -- `tests/bench_dlp.rs` lists them explicitly rather
 than scanning the directory, so `test-fixtures/documents/customer-form.pdf`
@@ -61,7 +65,18 @@ than scanning the directory, so `test-fixtures/documents/customer-form.pdf`
 
 - `customer-note.txt`, `customer.json`, `customer-profile.html`,
   `customers.csv`, `multilingual.txt`, `false-positives-en.txt`,
-  `dates-en.txt`
+  `dates-en.txt`, `contextual-en.txt`
+
+`contextual-en.txt` is a call summary written so that every PII item needs
+context rather than shape or capitalisation to find: a lower-case name
+(`jonas petersen`), a free-form address with no postcode keyword, a medical
+condition, a keyword-less date of birth (`12/03/1984`, indistinguishable by
+shape from a plain date), a forum handle and a username. It also carries two
+non-PII controls that read like an organisation out of context (`Apple
+Watch`, `The Support Desk`) to check for over-redaction by entity-based
+providers. `local-rules` and plain `local-ner` are not expected to find most
+of this file's PII; it exists to show what a context-aware provider adds over
+the regex/NER baseline.
 
 Total corpus size is under 3 KB.
 
@@ -85,8 +100,8 @@ cargo test --release --test bench_dlp -- --ignored --nocapture
 Configuration is via environment variables:
 
 - `BENCH_DLP_PROVIDERS`: comma-separated provider specs. Defaults to
-  `local-rules,local-ner,local-rules+local-ner` (local providers only, no
-  network calls).
+  `local-rules,local-ner,local-rules+local-ner,local-gliner,local-rules+local-gliner`
+  (local providers only, no network calls).
 - `BENCH_DLP_GCP_PROJECT`: GCP project id, required only when a `gcp-dlp` or
   `gcp-vertex-ai` spec is listed; the test fails fast with a clear message if
   it's missing.
@@ -99,10 +114,10 @@ Local providers only (the default):
 cargo test --release --test bench_dlp -- --ignored --nocapture
 ```
 
-All five providers, including the cloud ones (requires GCP credentials):
+All seven providers, including the cloud ones (requires GCP credentials):
 
 ```sh
-BENCH_DLP_PROVIDERS=local-rules,local-ner,local-rules+local-ner,gcp-dlp,gcp-vertex-ai \
+BENCH_DLP_PROVIDERS=local-rules,local-ner,local-rules+local-ner,local-gliner,local-rules+local-gliner,gcp-dlp,gcp-vertex-ai \
 BENCH_DLP_GCP_PROJECT=latestbit \
 cargo test --release --test bench_dlp -- --ignored --nocapture
 ```
@@ -127,11 +142,11 @@ separate passes.
 ### Cloud cost note
 
 Each cloud provider spec is invoked exactly `1 + 3 + <file count>` times per
-run (currently 7 corpus files, so 11 invocations). The test prints this count
+run (currently 8 corpus files, so 12 invocations). The test prints this count
 before starting and aborts if it would ever be exceeded -- there is no retry
-loop. Across those 11 invocations, the whole ~3 KB corpus is sent roughly 5
+loop. Across those 12 invocations, the whole ~4 KB corpus is sent roughly 5
 times over (4 whole-corpus passes' worth of bytes, plus the per-file passes
-covering the corpus once more), so each cloud provider sees under 40 KB total
+covering the corpus once more), so each cloud provider sees under 45 KB total
 per run.
 
 ## Scoring
@@ -151,36 +166,55 @@ and writes it to `<BENCH_DLP_OUT>/summary.md`:
 
 ## Results
 
-Local rows measured at commit `540fbc5` (2026-09-07,
-`cargo test --release --test bench_dlp -- --ignored --nocapture`), cloud rows
-from the full run at commit `3c3491e`; Intel(R) Core(TM) i7-10700K CPU @
-3.80GHz (16 logical cores). All providers completed cleanly (11/11 calls made
-each, no errors, no retries needed).
+Local rows measured at commit `257e8eb` (2026-09-08,
+`cargo test --release --test bench_dlp -- --ignored --nocapture`) on the
+8-file corpus (48 pii / 8 entities / 31 keep); Intel(R) Core(TM) i7-10700K
+CPU @ 3.80GHz (16 logical cores). All five local providers completed cleanly
+(12/12 calls made each, no errors, no retries needed).
+
+Cloud rows are kept from the 7-file corpus run at commit `3c3491e`
+(2026-09-07, 41 pii / 7 entities / 25 keep, before `contextual-en.txt` joined
+the corpus) and were not re-run this round; their pii/entities/keep totals
+are out of 41/7/25, not the 48/8/31 the local rows use below.
 
 | provider | wall time (median of 3) | per-file median | pii hits/total | loc/org redacted/total | keep survived/total | [REDACTED] count |
 |---|---|---|---|---|---|---|
-| gcp-dlp | 710 ms | 266 ms | 40/41 | 4/7 | 25/25 | 73 |
-| gcp-vertex-ai | 68901 ms | 5999 ms | 41/41 | 1/7 | 24/25 | 48 |
-| local-ner | 370 ms | 144 ms | 15/41 | 7/7 | 23/25 | 32 |
-| local-rules | 38 ms | 35 ms | 28/41 | 0/7 | 25/25 | 31 |
-| local-rules+local-ner | 431 ms | 174 ms | 41/41 | 7/7 | 23/25 | 63 |
+| gcp-dlp (7-file corpus) | 710 ms | 266 ms | 40/41 | 4/7 | 25/25 | 73 |
+| gcp-vertex-ai (7-file corpus) | 68901 ms | 5999 ms | 41/41 | 1/7 | 24/25 | 48 |
+| local-rules | 51 ms | 49 ms | 28/48 | 0/8 | 31/31 | 31 |
+| local-ner | 409 ms | 146 ms | 17/48 | 8/8 | 27/31 | 37 |
+| local-rules+local-ner | 468 ms | 192 ms | 43/48 | 8/8 | 27/31 | 68 |
+| local-gliner | 2357 ms | 784 ms | 45/48 | 1/8 | 28/31 | 51 |
+| local-rules+local-gliner | 2492 ms | 823 ms | 48/48 | 1/8 | 27/31 | 59 |
 
 ### Reading the numbers
 
-`local-rules` is by far the fastest (about 20 ms) and now catches the
-structured PII including the dates of birth, the postcode and the passport
-number (28/41), missing only names and street addresses, while leaving every
-control string and every city/org name untouched. `local-ner` alone inverts
-that gap: it catches names and all seven `entities` but has no notion of
-email/phone/card/id formats, so it lands at a low 15/41 pii hits.
-`local-rules+local-ner`, the intended production configuration, is additive
-on detection (41/41 pii hits, all entities) at essentially `local-ner`'s
-latency (431 ms), since the regex pass is negligible next to the NER model.
-The chain now matches `gcp-vertex-ai` on raw pii recall (41/41 both) and
-beats `gcp-dlp` (40/41), and both cloud providers leave keep strings alone
-almost as well, but neither is a drop-in replacement for the chain's
-entity coverage (`gcp-dlp` 4/7, `gcp-vertex-ai` 1/7 loc/org redacted, versus
-7/7 for `local-ner`/the chain); `gcp-dlp` is close to the chain's latency
-(710 ms vs 431 ms) while `gcp-vertex-ai` is two orders of magnitude slower
-(69 s median, up to 21 s for a single small file), the clear cost of routing
-every file through an LLM.
+`local-rules` is by far the fastest (about 50 ms) and catches the structured
+PII including the dates of birth, the postcode and the passport number
+(28/48), missing the names and free-form addresses that have no shape to
+match, while leaving every control string alone (31/31 keep). `local-ner`
+alone inverts that gap: it catches names and all eight `entities` but has no
+notion of email/phone/card/id formats or of context, so it lands at 17/48 pii
+hits and misses three of the contextual fixture's context-only items.
+`local-rules+local-ner` is additive on the structured/named split (43/48 pii,
+all entities) at essentially `local-ner`'s latency (468 ms), but is still
+short of the full 48 because neither half of the chain reads context: the
+keyword-less date of birth and the free-form address in `contextual-en.txt`
+need more than shape or a name-shaped token to find.
+
+`local-gliner` on its own reaches 45/48 pii at default settings (a 14-label
+PII-only list, no `organization`) and, chained after `local-rules`, reaches
+48/48 -- every PII string in the corpus, including the lower-case name,
+medical condition, keyword-less date of birth and the two handles in
+`contextual-en.txt` that neither `local-rules` nor `local-ner` find. It costs
+about 5x `local-rules+local-ner`'s latency (2492 ms vs 468 ms wall,
+mostly one-time model load repeated per invocation in this per-process
+harness) and, since `organization` is off by default, redacts only 1 of 8
+`entities` (the address's town name, tagged under the `address` label) rather
+than `local-ner`'s 8/8 -- entity coverage costs an extra label and the false
+positives that come with it (see the `local-gliner` section of the top-level
+README). Compared to the cloud rows on the smaller 7-file corpus,
+`local-rules+local-gliner`'s 48/48 pii on the harder 8-file corpus is not
+directly comparable, but the contextual fixture is exactly the kind of gap
+`gcp-vertex-ai`'s LLM-based redaction is included here to cover; a like-for-like
+comparison needs the cloud providers re-run on the current corpus.

--- a/test-fixtures/bench-dlp/README.md
+++ b/test-fixtures/bench-dlp/README.md
@@ -78,7 +78,7 @@ providers. `local-rules` and plain `local-ner` are not expected to find most
 of this file's PII; it exists to show what a context-aware provider adds over
 the regex/NER baseline.
 
-Total corpus size is under 3 KB.
+Total corpus size is under 4 KB.
 
 The corpus is text only, on purpose, so this benchmark says nothing about the
 OCR path (images and PDFs read through the OCR engine before redaction): that
@@ -166,7 +166,7 @@ and writes it to `<BENCH_DLP_OUT>/summary.md`:
 
 ## Results
 
-Local rows measured at commit `257e8eb` (2026-09-08,
+Local rows measured at commit `f1f7ea2` (2026-09-08,
 `cargo test --release --test bench_dlp -- --ignored --nocapture`) on the
 8-file corpus (48 pii / 8 entities / 31 keep); Intel(R) Core(TM) i7-10700K
 CPU @ 3.80GHz (16 logical cores). All five local providers completed cleanly
@@ -193,14 +193,17 @@ are out of 41/7/25, not the 48/8/31 the local rows use below.
 PII including the dates of birth, the postcode and the passport number
 (28/48), missing the names and free-form addresses that have no shape to
 match, while leaving every control string alone (31/31 keep). `local-ner`
-alone inverts that gap: it catches names and all eight `entities` but has no
-notion of email/phone/card/id formats or of context, so it lands at 17/48 pii
-hits and misses three of the contextual fixture's context-only items.
-`local-rules+local-ner` is additive on the structured/named split (43/48 pii,
-all entities) at essentially `local-ner`'s latency (468 ms), but is still
-short of the full 48 because neither half of the chain reads context: the
-keyword-less date of birth and the free-form address in `contextual-en.txt`
-need more than shape or a name-shaped token to find.
+alone inverts that gap: it catches names, capitalised addresses and all
+eight `entities` but has no notion of email/phone/card/id formats, so it
+lands at 17/48 pii hits, missing five of the contextual fixture's seven PII
+items: the lower-case name (NER needs capitalisation), the medical
+condition, the keyword-less date of birth and the two handles -- none of
+which are person, organisation or location entities to begin with.
+`local-rules+local-ner` is additive on the structured/named split (43/48
+pii, all entities) at essentially `local-ner`'s latency (468 ms), but stays
+short of the full 48 for the same reason: neither half of the chain has a
+notion of a medical condition, a handle, or a date of birth with no keyword
+and no NER-recognisable shape.
 
 `local-gliner` on its own reaches 45/48 pii at default settings (a 14-label
 PII-only list, no `organization`) and, chained after `local-rules`, reaches

--- a/test-fixtures/bench-dlp/README.md
+++ b/test-fixtures/bench-dlp/README.md
@@ -166,7 +166,7 @@ and writes it to `<BENCH_DLP_OUT>/summary.md`:
 
 ## Results
 
-Local rows measured at commit `f1f7ea2` (2026-09-08,
+Local rows measured at commit `e9b325d` (2026-09-08,
 `cargo test --release --test bench_dlp -- --ignored --nocapture`) on the
 8-file corpus (48 pii / 8 entities / 31 keep); Intel(R) Core(TM) i7-10700K
 CPU @ 3.80GHz (16 logical cores). All five local providers completed cleanly
@@ -181,11 +181,11 @@ are out of 41/7/25, not the 48/8/31 the local rows use below.
 |---|---|---|---|---|---|---|
 | gcp-dlp (7-file corpus) | 710 ms | 266 ms | 40/41 | 4/7 | 25/25 | 73 |
 | gcp-vertex-ai (7-file corpus) | 68901 ms | 5999 ms | 41/41 | 1/7 | 24/25 | 48 |
-| local-rules | 51 ms | 49 ms | 28/48 | 0/8 | 31/31 | 31 |
-| local-ner | 409 ms | 146 ms | 17/48 | 8/8 | 27/31 | 37 |
-| local-rules+local-ner | 468 ms | 192 ms | 43/48 | 8/8 | 27/31 | 68 |
-| local-gliner | 2357 ms | 784 ms | 45/48 | 1/8 | 28/31 | 51 |
-| local-rules+local-gliner | 2492 ms | 823 ms | 48/48 | 1/8 | 27/31 | 59 |
+| local-rules | 52 ms | 49 ms | 28/48 | 0/8 | 31/31 | 31 |
+| local-ner | 441 ms | 152 ms | 17/48 | 8/8 | 27/31 | 37 |
+| local-rules+local-ner | 466 ms | 205 ms | 43/48 | 8/8 | 27/31 | 68 |
+| local-gliner | 2827 ms | 834 ms | 48/48 | 1/8 | 28/31 | 54 |
+| local-rules+local-gliner | 2727 ms | 878 ms | 48/48 | 1/8 | 27/31 | 59 |
 
 ### Reading the numbers
 
@@ -205,13 +205,14 @@ short of the full 48 for the same reason: neither half of the chain has a
 notion of a medical condition, a handle, or a date of birth with no keyword
 and no NER-recognisable shape.
 
-`local-gliner` on its own reaches 45/48 pii at default settings (a 14-label
-PII-only list, no `organization`) and, chained after `local-rules`, reaches
-48/48 -- every PII string in the corpus, including the lower-case name,
-medical condition, keyword-less date of birth and the two handles in
-`contextual-en.txt` that neither `local-rules` nor `local-ner` find. It costs
-about 5x `local-rules+local-ner`'s latency (2492 ms vs 468 ms wall,
-mostly one-time model load repeated per invocation in this per-process
+`local-gliner` on its own reaches 48/48 pii at default settings (a 14-label
+PII-only list, no `organization`) -- every PII string in the corpus,
+including the lower-case name, medical condition, keyword-less date of birth
+and the two handles in `contextual-en.txt` that neither `local-rules` nor
+`local-ner` find; chaining it after `local-rules` adds nothing on this corpus
+but keeps the rules' checksummed identifiers for documents the model has not
+seen. It costs about 6x `local-rules+local-ner`'s latency (2727 ms vs 466 ms
+wall, mostly the model load repeated per invocation in this per-process
 harness) and, since `organization` is off by default, redacts only 1 of 8
 `entities` (the address's town name, tagged under the `address` label) rather
 than `local-ner`'s 8/8 -- entity coverage costs an extra label and the false

--- a/test-fixtures/bench-dlp/truth.json
+++ b/test-fixtures/bench-dlp/truth.json
@@ -121,5 +121,27 @@
       "January 2024",
       "invoice"
     ]
+  },
+  "contextual-en.txt": {
+    "pii": [
+      "jonas petersen",
+      "14 Rosewood Lane, Kettering",
+      "type 2 diabetes",
+      "Mira Kowalczyk",
+      "12/03/1984",
+      "@mira_k84",
+      "mkowalczyk"
+    ],
+    "entities": [
+      "Kettering"
+    ],
+    "keep": [
+      "Apple Watch",
+      "The Support Desk",
+      "Tuesday morning",
+      "quarterly report",
+      "before Friday",
+      "glucose readings"
+    ]
   }
 }

--- a/test-fixtures/documents/contextual-en.txt
+++ b/test-fixtures/documents/contextual-en.txt
@@ -1,0 +1,17 @@
+Call summary, Tuesday morning
+
+I spoke with jonas petersen about the refund for his Apple Watch. He said the
+delivery went to the wrong place because he recently moved and now lives at
+14 Rosewood Lane, Kettering, just behind the old mill. He asked us to send the
+replacement there instead.
+
+He mentioned he was recently diagnosed with type 2 diabetes and asked whether
+the watch can track glucose readings from his sensor. I told him to check with
+The Support Desk, who handle device questions.
+
+His partner, Mira Kowalczyk, is the account holder. She turned forty this
+spring, so the file shows 12/03/1984 next to her name. Her forum handle is
+@mira_k84 and she logs into the portal as mkowalczyk.
+
+Follow-up: attach the quarterly report to the ticket and confirm the new
+address before Friday.

--- a/tests/bench_dlp.rs
+++ b/tests/bench_dlp.rs
@@ -14,8 +14,8 @@
 //! `test-fixtures/bench-dlp/` for the full description):
 //!
 //! - `BENCH_DLP_PROVIDERS`: comma-separated provider specs, e.g.
-//!   `local-rules,local-ner,local-rules+local-ner,gcp-dlp,gcp-vertex-ai`.
-//!   Defaults to `local-rules,local-ner,local-rules+local-ner`.
+//!   `local-rules,local-ner,local-rules+local-ner,local-gliner,local-rules+local-gliner,gcp-dlp,gcp-vertex-ai`.
+//!   Defaults to `local-rules,local-ner,local-rules+local-ner,local-gliner,local-rules+local-gliner`.
 //! - `BENCH_DLP_GCP_PROJECT`: GCP project id, required only when a `gcp-*`
 //!   provider is listed.
 //! - `BENCH_DLP_OUT`: output directory for run artifacts and `summary.md`.
@@ -32,7 +32,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Instant;
 
-/// The seven text-only fixtures that make up the corpus, read directly from
+/// The eight text-only fixtures that make up the corpus, read directly from
 /// `test-fixtures/documents/`. This is an explicit list, not a directory
 /// listing, so that `test-fixtures/documents/customer-form.pdf` (and anything
 /// else added there later) never becomes part of the corpus.
@@ -44,6 +44,7 @@ const CORPUS_FILE_NAMES: &[&str] = &[
     "multilingual.txt",
     "false-positives-en.txt",
     "dates-en.txt",
+    "contextual-en.txt",
 ];
 
 const REDACTED_TOKEN: &str = "[REDACTED]";
@@ -270,8 +271,10 @@ fn invoke_redacter(spec: &str, src: &Path, out_dir: &Path, gcp_project: Option<&
 #[test]
 #[ignore]
 fn bench_dlp() {
-    let providers_env = std::env::var("BENCH_DLP_PROVIDERS")
-        .unwrap_or_else(|_| "local-rules,local-ner,local-rules+local-ner".to_string());
+    let providers_env = std::env::var("BENCH_DLP_PROVIDERS").unwrap_or_else(|_| {
+        "local-rules,local-ner,local-rules+local-ner,local-gliner,local-rules+local-gliner"
+            .to_string()
+    });
     let specs: Vec<String> = providers_env
         .split(',')
         .map(|s| s.trim().to_string())


### PR DESCRIPTION
Adds a third offline redacter, local-gliner, running the zero-shot span model urchade/gliner_multi_pii-v1 (fp32 ONNX) on rten with the same pure-Rust dependencies as local-ner, so it ships in every release binary and downloads its 1.16 GB model only with --download-models consent. It reads context that rules and the NER model cannot: on the benchmark corpus, now extended with a contextual fixture, it redacts 48/48 PII strings alone where local-rules+local-ner reach 43/48, at about 0.8 s per file including model load. The default label list deliberately leaves out organization, which over-redacts team and desk names; README documents the flags, resource costs and known false positives.